### PR TITLE
support for record to table mapping config

### DIFF
--- a/documentation/QUICKSTART.md
+++ b/documentation/QUICKSTART.md
@@ -122,7 +122,7 @@ Example:
 ```
 kafka-avro-console-producer 
 --broker-list localhost:9092 
---topic example  
+--topic topic1  
 --property parse.key=true 
 --property key.schema='{"type":"record",name":"key_schema","fields":[{"name":"id","type":"int"}]}' 
 --property "key.separator=$" 
@@ -132,7 +132,7 @@ kafka-avro-console-producer
 ```
 
 Output upon running the select query in ScyllaDB:
-select * from demo.example;
+select * from test.topic1;
 
 ```
  id | firstname | lastname

--- a/src/main/java/io/connect/scylladb/RecordConverter.java
+++ b/src/main/java/io/connect/scylladb/RecordConverter.java
@@ -2,6 +2,7 @@ package io.connect.scylladb;
 
 import com.google.common.base.Preconditions;
 import io.connect.scylladb.topictotable.TopicConfigs;
+import io.connect.scylladb.utils.ScyllaDbConstants;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -59,10 +60,12 @@ public abstract class RecordConverter<T> {
     protected abstract void setNullField(T result, String name);
 
     public T convert(SinkRecord record, TopicConfigs topicConfigs, String operationType) {
-        Object recordObject = "delete".equals(operationType) ? record.key() : record.value();
+        Object recordObject = ScyllaDbConstants.DELETE_OPERATION.equals(operationType) ?
+                record.key() : record.value();
         T result = this.newValue();
         Map<String, TopicConfigs.KafkaScyllaColumnMapper> columnDetailsMap = null;
-        Preconditions.checkNotNull(recordObject, ("delete".equals(operationType) ? "key " : "value ") + "cannot be null.");
+        Preconditions.checkNotNull(recordObject,
+                (ScyllaDbConstants.DELETE_OPERATION.equals(operationType) ? "key " : "value ") + "cannot be null.");
         if (topicConfigs != null && topicConfigs.isScyllaColumnsMapped()) {
             columnDetailsMap = topicConfigs.getTableColumnMap();
             Preconditions.checkNotNull(record.key(), "key cannot be null.");

--- a/src/main/java/io/connect/scylladb/RecordConverter.java
+++ b/src/main/java/io/connect/scylladb/RecordConverter.java
@@ -61,10 +61,10 @@ public abstract class RecordConverter<T> {
     public T convert(SinkRecord record, TopicConfigs topicConfigs, String operationType) {
         Object recordObject = "delete".equals(operationType) ? record.key() : record.value();
         T result = this.newValue();
-        Map<String, TopicConfigs.KafkaScyllaColumnMapper> columnDetailsMap =
-                (null == topicConfigs) ? null : topicConfigs.getTableColumnMap();
+        Map<String, TopicConfigs.KafkaScyllaColumnMapper> columnDetailsMap = null;
         Preconditions.checkNotNull(recordObject, ("delete".equals(operationType) ? "key " : "value ") + "cannot be null.");
-        if (topicConfigs != null) {
+        if (topicConfigs != null && topicConfigs.isScyllaColumnsMapped()) {
+            columnDetailsMap = topicConfigs.getTableColumnMap();
             Preconditions.checkNotNull(record.key(), "key cannot be null.");
             findRecordTypeAndConvert(result, record.key(), topicConfigs.getTablePartitionKeyMap());
             for (Header header : record.headers()) {

--- a/src/main/java/io/connect/scylladb/RecordConverter.java
+++ b/src/main/java/io/connect/scylladb/RecordConverter.java
@@ -1,10 +1,13 @@
 package io.connect.scylladb;
 
 import com.google.common.base.Preconditions;
+import io.connect.scylladb.topictotable.TopicConfigs;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,23 +58,42 @@ public abstract class RecordConverter<T> {
 
     protected abstract void setNullField(T result, String name);
 
-    public T convert(Object value) {
-        Preconditions.checkNotNull(value, "value cannot be null.");
+    public T convert(SinkRecord record, TopicConfigs topicConfigs, String operationType) {
+        Object recordObject = "delete".equals(operationType) ? record.key() : record.value();
         T result = this.newValue();
-        if (value instanceof Struct) {
-            this.convertStruct(result, (Struct)value);
-        } else {
-            if (!(value instanceof Map)) {
-                throw new DataException(String.format("Only Schema (%s) or Schema less (%s) are supported. %s is not a supported type.", Struct.class.getName(), Map.class.getName(), value.getClass().getName()));
+        Map<String, TopicConfigs.KafkaScyllaColumnMapper> columnDetailsMap =
+                (null == topicConfigs) ? null : topicConfigs.getTableColumnMap();
+        Preconditions.checkNotNull(recordObject, ("delete".equals(operationType) ? "key " : "value ") + "cannot be null.");
+        if (topicConfigs != null) {
+            Preconditions.checkNotNull(record.key(), "key cannot be null.");
+            findRecordTypeAndConvert(result, record.key(), topicConfigs.getTablePartitionKeyMap());
+            for (Header header : record.headers()) {
+                if (topicConfigs.getTableColumnMap().containsKey(header.key())) {
+                    TopicConfigs.KafkaScyllaColumnMapper headerKafkaScyllaColumnMapper = topicConfigs.getTableColumnMap().get(header.key());
+                    parseStructAndSetInStatement(result, header.schema(),
+                            headerKafkaScyllaColumnMapper.getKafkaRecordField(), header.value(),
+                            headerKafkaScyllaColumnMapper.getScyllaColumnName());
+                }
             }
-
-            this.convertMap(result, (Map)value);
         }
-
+        findRecordTypeAndConvert(result, recordObject, columnDetailsMap);
         return result;
     }
 
-    void convertMap(T result, Map value) {
+    void findRecordTypeAndConvert(T result, Object recordObject,
+                                  Map<String, TopicConfigs.KafkaScyllaColumnMapper> columnDetailsMap) {
+        if (recordObject instanceof Struct) {
+            this.convertStruct(result, (Struct)recordObject, columnDetailsMap);
+        } else {
+            if (!(recordObject instanceof Map)) {
+                throw new DataException(String.format("Only Schema (%s) or Schema less (%s) are supported. %s is not a supported type.", Struct.class.getName(), Map.class.getName(), recordObject.getClass().getName()));
+            }
+
+            this.convertMap(result, (Map)recordObject, columnDetailsMap);
+        }
+    }
+
+    void convertMap(T result, Map value, Map<String, TopicConfigs.KafkaScyllaColumnMapper> columnDetailsMap) {
         Iterator valueIterator = value.keySet().iterator();
 
         while(valueIterator.hasNext()) {
@@ -79,6 +101,13 @@ public abstract class RecordConverter<T> {
             Preconditions.checkState(key instanceof String, "Map key must be a String.");
             String fieldName = (String)key;
             Object fieldValue = value.get(key);
+            if (columnDetailsMap != null) {
+                if (columnDetailsMap.containsKey(fieldName)) {
+                    fieldName = columnDetailsMap.get(fieldName).getScyllaColumnName();
+                } else {
+                    continue;
+                }
+            }
 
             try {
                 if (null == fieldValue) {
@@ -138,7 +167,7 @@ public abstract class RecordConverter<T> {
 
     }
 
-    void convertStruct(T result, Struct struct) {
+    void convertStruct(T result, Struct struct, Map<String, TopicConfigs.KafkaScyllaColumnMapper> columnDetailsMap) {
         Schema schema = struct.schema();
         Iterator fieldsIterator = schema.fields().iterator();
 
@@ -147,92 +176,101 @@ public abstract class RecordConverter<T> {
             String fieldName = field.name();
             log.trace("convertStruct() - Processing '{}'", field.name());
             Object fieldValue = struct.get(field);
-
-            try {
-                if (null == fieldValue) {
-                    log.trace("convertStruct() - Setting '{}' to null.", fieldName);
-                    this.setNullField(result, fieldName);
+            if (columnDetailsMap != null) {
+                if (columnDetailsMap.containsKey(fieldName)) {
+                    fieldName = columnDetailsMap.get(fieldName).getScyllaColumnName();
                 } else {
-                    log.trace("convertStruct() - Field '{}'.field().schema().type() = '{}'", fieldName, field.schema().type());
-                    switch(field.schema().type()) {
-                        case STRING:
-                            log.trace("convertStruct() - Processing '{}' as string.", fieldName);
-                            this.setStringField(result, fieldName, (String)fieldValue);
-                            break;
-                        case INT8:
-                            log.trace("convertStruct() - Processing '{}' as int8.", fieldName);
-                            this.setInt8Field(result, fieldName, (Byte)fieldValue);
-                            break;
-                        case INT16:
-                            log.trace("convertStruct() - Processing '{}' as int16.", fieldName);
-                            this.setInt16Field(result, fieldName, (Short)fieldValue);
-                            break;
-                        case INT32:
-                            if ("org.apache.kafka.connect.data.Date".equals(field.schema().name())) {
-                                log.trace("convertStruct() - Processing '{}' as date.", fieldName);
-                                this.setDateField(result, fieldName, (Date)fieldValue);
-                            } else if ("org.apache.kafka.connect.data.Time".equals(field.schema().name())) {
-                                log.trace("convertStruct() - Processing '{}' as time.", fieldName);
-                                this.setTimeField(result, fieldName, (Date)fieldValue);
-                            } else {
-                                Integer int32Value = (Integer)fieldValue;
-                                log.trace("convertStruct() - Processing '{}' as int32.", fieldName);
-                                this.setInt32Field(result, fieldName, int32Value);
-                            }
-                            break;
-                        case INT64:
-                            if ("org.apache.kafka.connect.data.Timestamp".equals(field.schema().name())) {
-                                log.trace("convertStruct() - Processing '{}' as timestamp.", fieldName);
-                                this.setTimestampField(result, fieldName, (Date)fieldValue);
-                            } else {
-                                Long int64Value = (Long)fieldValue;
-                                log.trace("convertStruct() - Processing '{}' as int64.", fieldName);
-                                this.setInt64Field(result, fieldName, int64Value);
-                            }
-                            break;
-                        case BYTES:
-                            if ("org.apache.kafka.connect.data.Decimal".equals(field.schema().name())) {
-                                log.trace("convertStruct() - Processing '{}' as decimal.", fieldName);
-                                this.setDecimalField(result, fieldName, (BigDecimal)fieldValue);
-                            } else {
-                                byte[] bytes = (byte[])((byte[])fieldValue);
-                                log.trace("convertStruct() - Processing '{}' as bytes.", fieldName);
-                                this.setBytesField(result, fieldName, bytes);
-                            }
-                            break;
-                        case FLOAT32:
-                            log.trace("convertStruct() - Processing '{}' as float32.", fieldName);
-                            this.setFloat32Field(result, fieldName, (Float)fieldValue);
-                            break;
-                        case FLOAT64:
-                            log.trace("convertStruct() - Processing '{}' as float64.", fieldName);
-                            this.setFloat64Field(result, fieldName, (Double)fieldValue);
-                            break;
-                        case BOOLEAN:
-                            log.trace("convertStruct() - Processing '{}' as boolean.", fieldName);
-                            this.setBooleanField(result, fieldName, (Boolean)fieldValue);
-                            break;
-                        case STRUCT:
-                            log.trace("convertStruct() - Processing '{}' as struct.", fieldName);
-                            this.setStructField(result, fieldName, (Struct)fieldValue);
-                            break;
-                        case ARRAY:
-                            log.trace("convertStruct() - Processing '{}' as array.", fieldName);
-                            this.setArray(result, fieldName, schema, (List)fieldValue);
-                            break;
-                        case MAP:
-                            log.trace("convertStruct() - Processing '{}' as map.", fieldName);
-                            this.setMap(result, fieldName, schema, (Map)fieldValue);
-                            break;
-                        default:
-                            throw new DataException("Unsupported schema.type(): " + schema.type());
-                    }
+                    continue;
                 }
-            } catch (Exception ex) {
-                throw new DataException(String.format("Exception thrown while processing field '%s'", fieldName), ex);
             }
+            parseStructAndSetInStatement(result, schema, field, fieldValue, fieldName);
         }
+    }
 
+    void parseStructAndSetInStatement(T result, Schema schema, Field field, Object fieldValue, String fieldName) {
+        try {
+            if (null == fieldValue) {
+                log.trace("convertStruct() - Setting '{}' to null.", fieldName);
+                this.setNullField(result, fieldName);
+            } else {
+                log.trace("convertStruct() - Field '{}'.field().schema().type() = '{}'", fieldName, field.schema().type());
+                switch(field.schema().type()) {
+                    case STRING:
+                        log.trace("convertStruct() - Processing '{}' as string.", fieldName);
+                        this.setStringField(result, fieldName, (String)fieldValue);
+                        break;
+                    case INT8:
+                        log.trace("convertStruct() - Processing '{}' as int8.", fieldName);
+                        this.setInt8Field(result, fieldName, (Byte)fieldValue);
+                        break;
+                    case INT16:
+                        log.trace("convertStruct() - Processing '{}' as int16.", fieldName);
+                        this.setInt16Field(result, fieldName, (Short)fieldValue);
+                        break;
+                    case INT32:
+                        if ("org.apache.kafka.connect.data.Date".equals(field.schema().name())) {
+                            log.trace("convertStruct() - Processing '{}' as date.", fieldName);
+                            this.setDateField(result, fieldName, (Date)fieldValue);
+                        } else if ("org.apache.kafka.connect.data.Time".equals(field.schema().name())) {
+                            log.trace("convertStruct() - Processing '{}' as time.", fieldName);
+                            this.setTimeField(result, fieldName, (Date)fieldValue);
+                        } else {
+                            Integer int32Value = (Integer)fieldValue;
+                            log.trace("convertStruct() - Processing '{}' as int32.", fieldName);
+                            this.setInt32Field(result, fieldName, int32Value);
+                        }
+                        break;
+                    case INT64:
+                        if ("org.apache.kafka.connect.data.Timestamp".equals(field.schema().name())) {
+                            log.trace("convertStruct() - Processing '{}' as timestamp.", fieldName);
+                            this.setTimestampField(result, fieldName, (Date)fieldValue);
+                        } else {
+                            Long int64Value = (Long)fieldValue;
+                            log.trace("convertStruct() - Processing '{}' as int64.", fieldName);
+                            this.setInt64Field(result, fieldName, int64Value);
+                        }
+                        break;
+                    case BYTES:
+                        if ("org.apache.kafka.connect.data.Decimal".equals(field.schema().name())) {
+                            log.trace("convertStruct() - Processing '{}' as decimal.", fieldName);
+                            this.setDecimalField(result, fieldName, (BigDecimal)fieldValue);
+                        } else {
+                            byte[] bytes = (byte[])((byte[])fieldValue);
+                            log.trace("convertStruct() - Processing '{}' as bytes.", fieldName);
+                            this.setBytesField(result, fieldName, bytes);
+                        }
+                        break;
+                    case FLOAT32:
+                        log.trace("convertStruct() - Processing '{}' as float32.", fieldName);
+                        this.setFloat32Field(result, fieldName, (Float)fieldValue);
+                        break;
+                    case FLOAT64:
+                        log.trace("convertStruct() - Processing '{}' as float64.", fieldName);
+                        this.setFloat64Field(result, fieldName, (Double)fieldValue);
+                        break;
+                    case BOOLEAN:
+                        log.trace("convertStruct() - Processing '{}' as boolean.", fieldName);
+                        this.setBooleanField(result, fieldName, (Boolean)fieldValue);
+                        break;
+                    case STRUCT:
+                        log.trace("convertStruct() - Processing '{}' as struct.", fieldName);
+                        this.setStructField(result, fieldName, (Struct)fieldValue);
+                        break;
+                    case ARRAY:
+                        log.trace("convertStruct() - Processing '{}' as array.", fieldName);
+                        this.setArray(result, fieldName, schema, (List)fieldValue);
+                        break;
+                    case MAP:
+                        log.trace("convertStruct() - Processing '{}' as map.", fieldName);
+                        this.setMap(result, fieldName, schema, (Map)fieldValue);
+                        break;
+                    default:
+                        throw new DataException("Unsupported schema.type(): " + schema.type());
+                }
+            }
+        } catch (Exception ex) {
+            throw new DataException(String.format("Exception thrown while processing field '%s'", fieldName), ex);
+        }
     }
 }
 

--- a/src/main/java/io/connect/scylladb/ScyllaDbSession.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSession.java
@@ -4,9 +4,11 @@ import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Statement;
+import io.connect.scylladb.topictotable.TopicConfigs;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.io.Closeable;
 import java.util.Map;
@@ -44,10 +46,11 @@ public interface ScyllaDbSession extends Closeable {
     /**
      * Ensure that a table has a specified schema.
      * @param tableName name of the table
-     * @param keySchema schema that will be used for the primary key.
-     * @param valueSchema schema that will be used for the rest of the table.
+     * @param sinkRecord which will have keySchema that will be used for the primary key and
+     * valueSchema that will be used for the rest of the table.
+     * @param topicConfigs class containing mapping details for the record
      */
-    void createOrAlterTable(String tableName, Schema keySchema, Schema valueSchema);
+    void createOrAlterTable(String tableName, SinkRecord sinkRecord, TopicConfigs topicConfigs);
 
     /**
      * Flag to determine if the session is valid.
@@ -69,9 +72,10 @@ public interface ScyllaDbSession extends Closeable {
     /**
      * Method will return a RecordToBoundStatementConverter for an insert the supplied table.
      * @param tableName table to return the RecordToBoundStatementConverter for
+     * @param topicConfigs class containing mapping details for the record
      * @return RecordToBoundStatementConverter that can be used for the record.
      */
-    RecordToBoundStatementConverter insert(String tableName);
+    RecordToBoundStatementConverter insert(String tableName, TopicConfigs topicConfigs);
 
     /**
      * Method is used to add prepared statements for the offsets that are in the current batch.

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkConnector.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkConnector.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.connect.scylladb.utils.VersionUtil;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkTask.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkTask.java
@@ -19,6 +19,7 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Statement;
 import com.google.common.collect.Iterables;
+import io.connect.scylladb.utils.VersionUtil;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.RetriableException;

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkTaskHelper.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkTaskHelper.java
@@ -3,6 +3,7 @@ package io.connect.scylladb;
 import com.datastax.driver.core.BoundStatement;
 import com.google.common.base.Preconditions;
 import io.connect.scylladb.topictotable.TopicConfigs;
+import io.connect.scylladb.utils.ScyllaDbConstants;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
@@ -64,7 +65,7 @@ public class ScyllaDbSinkTaskHelper {
       if (deletionEnabled) {
         if (this.session.tableExists(tableName)) {
           final RecordToBoundStatementConverter boundStatementConverter = this.session.delete(tableName);
-          final RecordToBoundStatementConverter.State state = boundStatementConverter.convert(record, null, "delete");
+          final RecordToBoundStatementConverter.State state = boundStatementConverter.convert(record, null, ScyllaDbConstants.DELETE_OPERATION);
           Preconditions.checkState(
                   state.parameters > 0,
                   "key must contain the columns in the primary key."
@@ -83,7 +84,7 @@ public class ScyllaDbSinkTaskHelper {
     } else {
       this.session.createOrAlterTable(tableName, record, topicConfigs);
       final RecordToBoundStatementConverter boundStatementConverter = this.session.insert(tableName, topicConfigs);
-      final RecordToBoundStatementConverter.State state = boundStatementConverter.convert(record, topicConfigs, "insert");
+      final RecordToBoundStatementConverter.State state = boundStatementConverter.convert(record, topicConfigs, ScyllaDbConstants.INSERT_OPERATION);
       boundStatement = state.statement;
     }
 

--- a/src/main/java/io/connect/scylladb/topictotable/TopicConfigs.java
+++ b/src/main/java/io/connect/scylladb/topictotable/TopicConfigs.java
@@ -1,0 +1,236 @@
+package io.connect.scylladb.topictotable;
+
+import com.datastax.driver.core.ConsistencyLevel;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import io.connect.scylladb.ScyllaDbSinkConnectorConfig;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class TopicConfigs {
+
+  private static final Logger log = LoggerFactory.getLogger(TopicConfigs.class);
+  private String mappingStringForTopic;
+  private Map<String, KafkaScyllaColumnMapper> tablePartitionKeyMap;
+  private Map<String, KafkaScyllaColumnMapper> tableColumnMap;
+  private ConsistencyLevel consistencyLevel = null;
+  private String ttlMappedField;
+  private Integer ttl;
+  private String timeStampMappedField;
+  private Long timeStamp;
+  private boolean deletesEnabled;
+  private boolean isScyllaColumnsMapped;
+
+  public TopicConfigs(Map<String, String> configsMapForTheTopic,
+                      ScyllaDbSinkConnectorConfig scyllaDbSinkConnectorConfig) {
+    this.tablePartitionKeyMap = new HashMap<>();
+    this.tableColumnMap = new HashMap<>();
+    this.consistencyLevel = scyllaDbSinkConnectorConfig.consistencyLevel;
+    this.ttl = scyllaDbSinkConnectorConfig.ttl;
+    this.deletesEnabled = scyllaDbSinkConnectorConfig.deletesEnabled;
+    if (configsMapForTheTopic.containsKey("mapping")) {
+      this.mappingStringForTopic = configsMapForTheTopic.get("mapping");
+    }
+    if (configsMapForTheTopic.containsKey("deletesEnabled")) {
+      String deleteEnabledValue = configsMapForTheTopic.get("deletesEnabled");
+      if ("true".equalsIgnoreCase(deleteEnabledValue) || "false".equalsIgnoreCase(deleteEnabledValue)) {
+        this.deletesEnabled = Boolean.parseBoolean(deleteEnabledValue);
+      } else {
+        throw new DataException(
+                String.format("%s is not a valid value for deletesEnabled. Valid values are : true, false",
+                        deleteEnabledValue
+                )
+        );
+      }
+    }
+    try {
+      if (configsMapForTheTopic.containsKey("ttlSeconds")) {
+        this.ttl = Integer.parseInt(configsMapForTheTopic.get("ttlSeconds"));
+      }
+      if (configsMapForTheTopic.containsKey("consistencyLevel")) {
+        this.consistencyLevel = ConsistencyLevel.valueOf(configsMapForTheTopic.get("consistencyLevel"));
+      }
+    } catch (NumberFormatException e) {
+      throw new DataException(
+              String.format("The setting ttlSeconds must be of type Integer. %s is not a suppoerted type",
+                      configsMapForTheTopic.get("ttlSeconds").getClass().getName()));
+    } catch (IllegalArgumentException e) {
+      throw  new DataException(
+              String.format("%s is not a valid value for consistencyLevel. Valid values are %s",
+                      configsMapForTheTopic.get("consistencyLevel"), Arrays.toString(ConsistencyLevel.values()))
+      );
+    }
+  }
+
+  public void setTablePartitionAndColumnValues(SinkRecord record) {
+    for (String mappedEntry : this.mappingStringForTopic.split(",")) {
+      String[] columnNameMap = mappedEntry.split("=");
+      String recordField = columnNameMap[1].split("\\.").length > 0
+              ? columnNameMap[1].split("\\.")[1] : "";
+      String scyllaColumnName = columnNameMap[0].trim();
+      KafkaScyllaColumnMapper kafkaScyllaColumnMapper = new KafkaScyllaColumnMapper(scyllaColumnName);
+      if (columnNameMap[1].startsWith("key.")) {
+        if (record.keySchema() != null) {
+          kafkaScyllaColumnMapper.kafkaRecordField = getFiledForNameFromSchema(record.keySchema(), recordField, "record.keySchema()");
+        }
+        this.tablePartitionKeyMap.put(recordField, kafkaScyllaColumnMapper);
+      } else if (columnNameMap[1].startsWith("value.")) {
+        Field valueField = null;
+        if (record.valueSchema() != null) {
+          valueField = getFiledForNameFromSchema(record.valueSchema(), recordField, "record.valueSchema()");
+        }
+        if (scyllaColumnName.equals("__ttl")) {
+          ttlMappedField = recordField;
+        } else if (scyllaColumnName.equals("__timestamp")) {
+          timeStampMappedField = recordField;
+        } else {
+          kafkaScyllaColumnMapper.kafkaRecordField = valueField;
+          this.tableColumnMap.put(recordField, kafkaScyllaColumnMapper);
+        }
+      } else if (columnNameMap[1].startsWith("header.")) {
+        int index = 0;
+        for (Header header : record.headers()) {
+          if (header.key().equals(recordField)) {
+            if (header.schema().type().isPrimitive()) {
+              kafkaScyllaColumnMapper.kafkaRecordField = new Field(header.key(), index, header.schema());
+              tableColumnMap.put(recordField, kafkaScyllaColumnMapper);
+              index++;
+            } else {
+              throw new IllegalArgumentException(String.format("Header schema type should be of primitive type. "
+                      + "%s schema type is not allowed in header.", header.schema().type().getName()));
+            }
+          }
+        }
+      } else {
+        throw new IllegalArgumentException("field name must start with 'key.', 'value.' or 'header.'.");
+      }
+    }
+    this.isScyllaColumnsMapped = true;
+  }
+
+  private Field getFiledForNameFromSchema(Schema schema, String name, String schemaType) {
+    Field schemaField = schema.field(name);
+    if (null == schemaField) {
+      throw new DataException(
+              String.format(
+                      schemaType + " must contain all of key fields mentioned in the "
+                                + "'topic.my_topic.my_ks.my_table.mapping' config. " + schemaType
+                                + "is missing field '%s'. " + schemaType + " is used by the connector "
+                                + "to persist data to the table in ScyllaDb. Here are "
+                                + "the available fields for " + schemaType + "(%s).",
+                      name,
+                      Joiner.on(", ").join(
+                              schema.fields().stream().map(Field::name).collect(Collectors.toList())
+                      )
+              )
+      );
+    }
+    return schemaField;
+  }
+
+  public void setTtlAndTimeStampIfAvailable(SinkRecord record) {
+    this.timeStamp = record.timestamp();
+    if (timeStampMappedField != null) {
+      Object timeStampValue = getValueOfField(record.value(), timeStampMappedField);
+      if (timeStampValue instanceof Long) {
+        this.timeStamp = (Long) timeStampValue;
+      } else {
+        throw new DataException(
+                String.format("TimeStamp should be of type Long. But record provided for %s is of type %s",
+                        timeStampMappedField, timeStampValue.getClass().getName()
+                ));
+      }
+    }
+    if (ttlMappedField != null) {
+      Object ttlValue = getValueOfField(record.value(), ttlMappedField);
+      if (ttlValue instanceof  Integer) {
+        this.ttl = (Integer) ttlValue;
+      } else {
+        throw new DataException(
+                String.format("TTL should be of type Integer. But record provided for %s is of type %s",
+                        ttlMappedField, ttlValue.getClass().getName()
+                ));
+      }
+    }
+  }
+
+  public Object getValueOfField(Object value, String field) {
+    Preconditions.checkNotNull(value, "value cannot be null.");
+    if (value instanceof Struct) {
+      return ((Struct)value).get(field);
+    } else {
+      if (!(value instanceof Map)) {
+        throw new DataException(String.format("Only Schema (%s) or Schema less (%s) are supported. %s is not a supported type.", Struct.class.getName(), Map.class.getName(), value.getClass().getName()));
+      }
+      return ((Map)value).get(field);
+    }
+  }
+
+  public Map<String, KafkaScyllaColumnMapper> getTablePartitionKeyMap() {
+    return tablePartitionKeyMap;
+  }
+
+  public Map<String, KafkaScyllaColumnMapper> getTableColumnMap() {
+    return tableColumnMap;
+  }
+
+  public ConsistencyLevel getConsistencyLevel() {
+    return consistencyLevel;
+  }
+
+  public String getTtlMappedField() {
+    return ttlMappedField;
+  }
+
+  public Integer getTtl() {
+    return ttl;
+  }
+
+  public Long getTimeStamp() {
+    return timeStamp;
+  }
+
+  public boolean isScyllaColumnsMapped() {
+    return isScyllaColumnsMapped;
+  }
+
+  public void setScyllaColumnsMappedFalse() {
+    this.isScyllaColumnsMapped = false;
+  }
+
+  public String getMappingStringForTopic() {
+    return mappingStringForTopic;
+  }
+
+  public boolean isDeletesEnabled() {
+    return deletesEnabled;
+  }
+
+  public class KafkaScyllaColumnMapper {
+    private String scyllaColumnName;
+    private Field kafkaRecordField;
+
+    KafkaScyllaColumnMapper(String scyllaColumnName) {
+      this.scyllaColumnName = scyllaColumnName;
+    }
+
+    public String getScyllaColumnName() {
+      return scyllaColumnName;
+    }
+
+    public Field getKafkaRecordField() {
+      return kafkaRecordField;
+    }
+  }
+}

--- a/src/main/java/io/connect/scylladb/utils/ScyllaDbConstants.java
+++ b/src/main/java/io/connect/scylladb/utils/ScyllaDbConstants.java
@@ -1,0 +1,9 @@
+package io.connect.scylladb.utils;
+
+public class ScyllaDbConstants {
+
+    public static final String DELETE_OPERATION = "delete";
+
+    public static final String INSERT_OPERATION = "insert";
+
+}

--- a/src/main/java/io/connect/scylladb/utils/VersionUtil.java
+++ b/src/main/java/io/connect/scylladb/utils/VersionUtil.java
@@ -1,4 +1,4 @@
-package io.connect.scylladb;
+package io.connect.scylladb.utils;
 
 public class VersionUtil {
     public static String getVersion() {


### PR DESCRIPTION
Added support for the below configs:

1. "topic.my_topic.my_ks.my_table.mapping": "col1=key.f1, col2=value.f1, __ttl=value.f2, __timestamp=value.f3, col3=header.f1"
2. "topic.my_topic.my_ks.my_table.consistencyLevel": "LOCAL_ONE"
3. "topic.my_topic.my_ks.my_table.ttlSeconds": 1
4. "topic.my_topic.my_ks.my_table.deletesEnabled": "true"

Which will address the below:
- Display messages to determine the data structure of the topic messages.
- Create a topic-table map for Kafka messages that only contain a key and value in each record.
- For JSON fields, map individual fields in the structure to columns.
- Supports mapping individual fields from a Avro format field.
- Mapping a record with a key and Apache Kafka Struct value.
- Extract values from Kafka record header and write to the database table.
- Mapping messages to table that has a User Defined Type
- Ingest multiple topics and write to different tables.

Note: We are supporting only primitive data type to be mapped to table while extracting values from Kafka record header.