### PR TITLE
Replace dots in table name by underscores 

### DIFF
--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkTaskHelper.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkTaskHelper.java
@@ -49,7 +49,7 @@ public class ScyllaDbSinkTaskHelper {
   }
 
   public BoundStatement getBoundStatementForRecord(SinkRecord record) {
-    final String tableName = record.topic();
+    final String tableName = record.topic().replaceAll("\\.", "_");
     BoundStatement boundStatement = null;
     TopicConfigs topicConfigs = null;
     if (scyllaDbSinkConnectorConfig.topicWiseConfigs.containsKey(tableName)) {


### PR DESCRIPTION
ScyllaDB Connector fails to create table with the same name as topic, it it contains `.`. Because of that we suggest this issue by replacing dots `.` by underscores `_`, so Kafka topic `my.test.topic` will be mapped to `my_test_topic` table in scyllaDB. 

Close #13 

