### PR TITLE
Fix timestamp incorrect unit (off by 1000)

### DIFF
--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkTaskHelper.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkTaskHelper.java
@@ -95,7 +95,9 @@ public class ScyllaDbSinkTaskHelper {
       boundStatement.setDefaultTimestamp(topicConfigs.getTimeStamp());
     } else {
       boundStatement.setConsistencyLevel(this.scyllaDbSinkConnectorConfig.consistencyLevel);
-      boundStatement.setDefaultTimestamp(record.timestamp());
+      // Timestamps in Kafka (record.timestamp()) are in millisecond precision,
+      // while Scylla expects a microsecond precision: 1 ms = 1000 us.
+      boundStatement.setDefaultTimestamp(record.timestamp() * 1000);
     }
     return boundStatement;
   }

--- a/src/main/java/io/connect/scylladb/topictotable/TopicConfigs.java
+++ b/src/main/java/io/connect/scylladb/topictotable/TopicConfigs.java
@@ -140,7 +140,9 @@ public class TopicConfigs {
   }
 
   public void setTtlAndTimeStampIfAvailable(SinkRecord record) {
-    this.timeStamp = record.timestamp();
+    // Timestamps in Kafka (record.timestamp()) are in millisecond precision,
+    // while Scylla expects a microsecond precision: 1 ms = 1000 us.
+    this.timeStamp = record.timestamp() * 1000;
     if (timeStampMappedField != null) {
       Object timeStampValue = getValueOfField(record.value(), timeStampMappedField);
       if (timeStampValue instanceof Long) {


### PR DESCRIPTION
Fix timestamps set on `BoundStatement`: timestamps on bound statements expect a microsecond precision, but a Kafka timestamp with a millisecond precision was set without conversion.

Fixes #28 - when a CDC table was set as a destination, a row with invalid timestamp (in year 1970 due to invalid units) would be attempted to be inserted and it would fail, as 1970 is earlier than any CDC generation.