### PR TITLE
Remove CQL batching from connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,21 +61,6 @@ This is the default behaviour of the connector. Here, the offset is stored in th
 
 If you want that offset should be managed in kafka then you must specify ``scylladb.offset.storage.table.enable=false``. By default, this property is true (in this case offset will be stored in the ScyllaDB table).
 
----------------
-Troubleshooting
----------------
-
-If you encounter error messages like this:
-
-
-    Batch for [test.twitter] is of size 127.661KiB, exceeding specified threshold of 50.000KiB by 77.661KiB
-
-Or warning messages like this:
-
-    Batch for [test.twitter] is of size 25.885KiB, exceeding specified threshold of 5.000KiB by 20.885KiB
-
-Try adjusting the ``consumer.max.poll.records`` setting in the worker.properties for |kconnect-long|.
-
 -----------------------
 Reporting Kafka Metrics
 -----------------------

--- a/config/scylladb-sink-quickstart.properties
+++ b/config/scylladb-sink-quickstart.properties
@@ -57,7 +57,6 @@ scylladb.keyspace=<keyspace-name>
 #scylladb.execute.timeout.ms=30000
 #scylladb.ttl=null
 #scylladb.offset.storage.table.enable=true
-#scylladb.timestamp.resolution.ms=0
 
 ### Converter configs(AVRO):
 #key.converter=io.confluent.connect.avro.AvroConverter

--- a/config/scylladb-sink-quickstart.properties
+++ b/config/scylladb-sink-quickstart.properties
@@ -57,7 +57,6 @@ scylladb.keyspace=<keyspace-name>
 #scylladb.execute.timeout.ms=30000
 #scylladb.ttl=null
 #scylladb.offset.storage.table.enable=true
-#scylladb.max.batch.size.kb=5
 #scylladb.timestamp.resolution.ms=0
 
 ### Converter configs(AVRO):

--- a/documentation/CONFIG.md
+++ b/documentation/CONFIG.md
@@ -256,17 +256,6 @@ Also, these topic level configurations will be override the behavior of Connecto
   * Type: Boolean
   * Importance: Medium
   * Default Value: True
-
-``scylladb.max.batch.size.kb``
-
-  Maximum size(in kilobytes) of a single batch consisting ScyllaDB operations. This should be equal to 
-  batch_size_warn_threshold_in_kb and 1/10th of the batch_size_fail_threshold_in_kb configured in scylla.yaml. 
-  The default value is set to 5kb, any change in this configuration should be accompanied by change in scylla.yaml.
-
-  * Type: int
-  * Default: 5
-  * Valid Values: [1,...]
-  * Importance: high
   
 ``scylladb.timestamp.resolution.ms``
 

--- a/documentation/CONFIG.md
+++ b/documentation/CONFIG.md
@@ -257,16 +257,6 @@ Also, these topic level configurations will be override the behavior of Connecto
   * Importance: Medium
   * Default Value: True
   
-``scylladb.timestamp.resolution.ms``
-
-  The batch resolution time, in case of this value being zero, the Connector will not batch the records, 
-  else, kafka records within the resolution time will be batched. Default value is set to zero.
-
-  * Type: Long
-  * Importance: Low
-  * Valid Values: [0,...]
-  * Default Value: 0
-  
 ###ScyllaDB
 
 ``behavior.on.error``

--- a/src/main/java/io/connect/scylladb/ScyllaDbSession.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSession.java
@@ -1,6 +1,6 @@
 package io.connect.scylladb;
 
-import com.datastax.driver.core.BatchStatement;
+import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Statement;
@@ -78,11 +78,13 @@ public interface ScyllaDbSession extends Closeable {
     RecordToBoundStatementConverter insert(String tableName, TopicConfigs topicConfigs);
 
     /**
-     * Method is used to add prepared statements for the offsets that are in the current batch.
-     * @param batch statement batch that will be written to ScyllaDb
-     * @param offsetStates The list of SinkOffsetStates for the current batch of SinkRecords.
+     * Method generates a BoundStatement, that inserts the offset metadata
+     * for a given topic and partition.
+     * @param topicPartition topic and partition for the offset
+     * @param metadata offset metadata to be inserted
+     * @return statement that inserts the provided offset to Scylla.
      */
-    void addOffsetsToBatch(BatchStatement batch, Map<TopicPartition, OffsetAndMetadata> offsetStates);
+    BoundStatement getInsertOffsetStatement(TopicPartition topicPartition, OffsetAndMetadata metadata);
 
     /**
      * Method is used to load offsets from storage in ScyllaDb

--- a/src/main/java/io/connect/scylladb/ScyllaDbSessionImpl.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSessionImpl.java
@@ -1,6 +1,5 @@
 package io.connect.scylladb;
 
-import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.KeyspaceMetadata;
@@ -170,33 +169,25 @@ class ScyllaDbSessionImpl implements ScyllaDbSession {
 
   private PreparedStatement offsetPreparedStatement;
 
-
   @Override
-  public void addOffsetsToBatch(
-      BatchStatement batch,
-      Map<TopicPartition, OffsetAndMetadata> currentOffsets
-  ) {
-    for (Map.Entry<TopicPartition, OffsetAndMetadata> kvp : currentOffsets.entrySet()) {
-      final TopicPartition topicPartition = kvp.getKey();
-      final OffsetAndMetadata metadata = kvp.getValue();
-
-      final BoundStatement statement;
-      if (null == this.offsetPreparedStatement) {
-        this.offsetPreparedStatement =
-            createInsertPreparedStatement(this.config.offsetStorageTable, null);
-      }
-      log.debug(
-          "addOffsetsToBatch() - Setting offset to {}:{}:{}",
-          topicPartition.topic(),
-          topicPartition.partition(),
-          metadata.offset()
-      );
-      statement = offsetPreparedStatement.bind();
-      statement.setString("topic", topicPartition.topic());
-      statement.setInt("partition", topicPartition.partition());
-      statement.setLong("offset", metadata.offset());
-      batch.add(statement);
+  public BoundStatement getInsertOffsetStatement(
+      TopicPartition topicPartition,
+      OffsetAndMetadata metadata) {
+    if (null == this.offsetPreparedStatement) {
+      this.offsetPreparedStatement =
+              createInsertPreparedStatement(this.config.offsetStorageTable, null);
     }
+    log.debug(
+            "getAddOffsetsStatement() - Setting offset to {}:{}:{}",
+            topicPartition.topic(),
+            topicPartition.partition(),
+            metadata.offset()
+    );
+    final BoundStatement statement = offsetPreparedStatement.bind();
+    statement.setString("topic", topicPartition.topic());
+    statement.setInt("partition", topicPartition.partition());
+    statement.setLong("offset", metadata.offset());
+    return statement;
   }
 
   @Override

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkConnectorConfig.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkConnectorConfig.java
@@ -52,7 +52,6 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
   public final String offsetStorageTable;
   public final long statementTimeoutMs;
   public final String loadBalancingLocalDc;
-  public final long timestampResolutionMs;
   public final Map<String, TopicConfigs> topicWiseConfigs;
   public final Integer ttl;
   public final BehaviorOnError behaviourOnError;
@@ -140,7 +139,6 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
     this.offsetStorageTable = getString(OFFSET_STORAGE_TABLE_CONF);
     this.statementTimeoutMs = getLong(EXECUTE_STATEMENT_TIMEOUT_MS_CONF);
     this.loadBalancingLocalDc = getString(LOAD_BALANCING_LOCAL_DC_CONFIG);
-    this.timestampResolutionMs = getLong(TIMESTAMP_RESOLUTION_MS_CONF);
     this.behaviourOnError = BehaviorOnError.valueOf(getString(BEHAVIOR_ON_ERROR_CONFIG).toUpperCase());
 
     Map<String, Map<String, String>> topicWiseConfigsMap = new HashMap<>();
@@ -277,12 +275,6 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
           + "After this interval elapses, Scylladb will remove these records. "
           + "If this configuration is not provided, the Sink Connector will perform "
           + "insert operations in ScyllaDB  without TTL setting.";
-
-
-  public static final String TIMESTAMP_RESOLUTION_MS_CONF = "scylladb.timestamp.resolution.ms";
-  private static final String TIMESTAMP_RESOLUTION_MS_DOC = "The batch resolution time, "
-          + "in case of this value being zero, the Connector will not batch the records, else, "
-          + "kafka records within the resolution time will be batched. Default value is set to zero.";
 
   private static final String LOAD_BALANCING_LOCAL_DC_CONFIG = "scylladb.loadbalancing.localdc";
   private static final String LOAD_BALANCING_LOCAL_DC_DEFAULT = "";
@@ -597,17 +589,6 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
                     4,
                     ConfigDef.Width.SHORT,
                     "Enable offset stored in ScyllaDB")
-            .define(
-                    TIMESTAMP_RESOLUTION_MS_CONF,
-                    ConfigDef.Type.LONG,
-                    0,
-                    ConfigDef.Range.atLeast(0),
-                    ConfigDef.Importance.LOW,
-                    TIMESTAMP_RESOLUTION_MS_DOC,
-                    WRITE_GROUP,
-                    6,
-                    ConfigDef.Width.SHORT,
-                    "Timestamp Threshold (in ms)")
             .define(
                     BEHAVIOR_ON_ERROR_CONFIG,
                     ConfigDef.Type.STRING,

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkConnectorConfig.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkConnectorConfig.java
@@ -51,7 +51,6 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
   public final File keyStorePath;
   public final String offsetStorageTable;
   public final long statementTimeoutMs;
-  public final int maxBatchSizeKb;
   public final String loadBalancingLocalDc;
   public final long timestampResolutionMs;
   public final Map<String, TopicConfigs> topicWiseConfigs;
@@ -140,7 +139,6 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
 
     this.offsetStorageTable = getString(OFFSET_STORAGE_TABLE_CONF);
     this.statementTimeoutMs = getLong(EXECUTE_STATEMENT_TIMEOUT_MS_CONF);
-    this.maxBatchSizeKb = getInt(MAX_BATCH_SIZE_CONFIG);
     this.loadBalancingLocalDc = getString(LOAD_BALANCING_LOCAL_DC_CONFIG);
     this.timestampResolutionMs = getLong(TIMESTAMP_RESOLUTION_MS_CONF);
     this.behaviourOnError = BehaviorOnError.valueOf(getString(BEHAVIOR_ON_ERROR_CONFIG).toUpperCase());
@@ -280,13 +278,6 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
           + "If this configuration is not provided, the Sink Connector will perform "
           + "insert operations in ScyllaDB  without TTL setting.";
 
-  public static final String MAX_BATCH_SIZE_CONFIG = "scylladb.max.batch.size.kb";
-  public static final int MAX_BATCH_SIZE_DEFAULT = 5;
-  private static final String MAX_BATCH_SIZE_DOC = "Maximum size(in kilobytes) of a single batch "
-          + "consisting ScyllaDB operations. The should be equal to batch_size_warn_threshold_in_kb "
-          + "and 1/10th of the batch_size_fail_threshold_in_kb configured in scylla.yaml. "
-          + "The default value is set to 5kb, any change in this configuration should be accompanied by "
-          + "change in scylla.yaml.";
 
   public static final String TIMESTAMP_RESOLUTION_MS_CONF = "scylladb.timestamp.resolution.ms";
   private static final String TIMESTAMP_RESOLUTION_MS_DOC = "The batch resolution time, "
@@ -606,17 +597,6 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
                     4,
                     ConfigDef.Width.SHORT,
                     "Enable offset stored in ScyllaDB")
-            .define(
-                    MAX_BATCH_SIZE_CONFIG,
-                    ConfigDef.Type.INT,
-                    MAX_BATCH_SIZE_DEFAULT,
-                    ConfigDef.Range.atLeast(1),
-                    ConfigDef.Importance.HIGH,
-                    MAX_BATCH_SIZE_DOC,
-                    WRITE_GROUP,
-                    5,
-                    ConfigDef.Width.LONG,
-                    "Max Batch Size (in kb)")
             .define(
                     TIMESTAMP_RESOLUTION_MS_CONF,
                     ConfigDef.Type.LONG,

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkTask.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkTask.java
@@ -11,7 +11,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
-import com.datastax.driver.core.BatchStatement;
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.ConsistencyLevel;
@@ -144,17 +143,6 @@ public class ScyllaDbSinkTask extends SinkTask {
         throw new RetriableException(ex);
       }
     }
-  }
-
-  private boolean isRecordWithinTimestampResolution(BoundStatement boundStatement,
-                                                    BatchStatement latestBatchStatement) {
-    long timeDiffFromInitialRecord = boundStatement.getDefaultTimestamp()
-            - Iterables.get(latestBatchStatement.getStatements(), 0).getDefaultTimestamp();
-    return timeDiffFromInitialRecord <= config.timestampResolutionMs;
-  }
-
-  private static int statementSize(Statement statement) {
-    return statement.requestSizeInBytes(ProtocolVersion.V4, CodecRegistry.DEFAULT_INSTANCE);
   }
 
   /**

--- a/src/test/java/io/connect/scylladb/integration/ScyllaDbSinkConnectorIT.java
+++ b/src/test/java/io/connect/scylladb/integration/ScyllaDbSinkConnectorIT.java
@@ -813,9 +813,9 @@ public class ScyllaDbSinkConnectorIT {
               topicPartition, new OffsetAndMetadata(123451234L)
       );
 
-      BatchStatement statement = new BatchStatement();
-      session.addOffsetsToBatch(statement, offsets);
-      session.executeStatement(statement);
+      offsets.entrySet().stream()
+        .map(e -> session.getInsertOffsetStatement(e.getKey(), e.getValue()))
+        .forEach(session::executeStatement);
     }
     this.task.start(settings);
     task.put(


### PR DESCRIPTION
Remove batching from `ScyllaDbSinkTask`. The rows are now inserted one-by-one in parallel (1 Future per 1 INSERT). 

Using (unlogged) batches was not correct as:
1. The heuristic calculating batch size was incorrect, resulting in warning log messages (batch too big).
2. The batches could span multiple Scylla partitions, in which case they are not recommended and could lead to degraded performance.

I observed better performance and better CPU utilization after this fix.

I also removed inserting offsets in (logged!) batches - I don't think there was any reason for it, and this logged batch could touch rows in many different Scylla nodes (across multiple partitions).

Removed `scylladb.timestamp.resolution.ms`, as this is not relevant if we are not doing batches. Similarly, removed `scylladb.max.batch.size.kb`.