### PR TITLE
Fix VersionUtil::getVersion()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,13 @@
                 </executions>
             </plugin>
         </plugins>
+        <resources>
+            <!-- Apply the properties set in the POM to the resource files -->
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
     </build>
 
     <dependencies>

--- a/src/main/java/io/connect/scylladb/utils/VersionUtil.java
+++ b/src/main/java/io/connect/scylladb/utils/VersionUtil.java
@@ -1,11 +1,29 @@
 package io.connect.scylladb.utils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 public class VersionUtil {
-    public static String getVersion() {
+    private static final Logger log = LoggerFactory.getLogger(VersionUtil.class);
+    private static final Properties VERSION = loadVersion();
+
+    private static Properties loadVersion() {
+        // Load the version from version.properties resource file.
+        InputStream inputStream = VersionUtil.class.getClassLoader().getResourceAsStream("io/connect/scylladb/version.properties");
+        Properties props = new Properties();
         try {
-            return VersionUtil.class.getPackage().getImplementationVersion();
-        } catch (Exception ex) {
-            return "0.0.0.0";
+            props.load(inputStream);
+        } catch (IOException e) {
+            log.error("Error loading the connector version");
         }
+        return props;
+    }
+
+    public static String getVersion() {
+        return VERSION.getProperty("version");
     }
 }


### PR DESCRIPTION
Fix VersionUtil::getVersion(). The new way the version is loaded is inspired by Debezium connectors and Scylla CDC Source Connector.

The version is stored in `version.properties` resource file and Maven during the build-time fills this file with a version number. `VersionUtil` can then read it in runtime, by loading the properties file.

Fixes #39.