### PR TITLE
Fix documentation about delivery guarantees

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ This is the default behaviour of the connector. Here, the offset is stored in th
 
 If you want that offset should be managed in kafka then you must specify ``scylladb.offset.storage.table.enable=false``. By default, this property is true (in this case offset will be stored in the ScyllaDB table).
 
+-------------------
+Delivery guarantees
+-------------------
+This connector has at-least-once semantics. In case of a crash or restart, an `INSERT` operation of some rows
+might be performed multiple times (at least once). However, `INSERT` operations are idempotent in Scylla, meaning
+there won't be any duplicate rows in the destination table.
+ 
+The only time you could see the effect of duplicate `INSERT` operations is if your destination table has 
+[Scylla CDC](https://docs.scylladb.com/using-scylla/cdc/) turned on. In the CDC log table you would see duplicate
+`INSERT` operations as separate CDC log rows. 
+
 -----------------------
 Reporting Kafka Metrics
 -----------------------

--- a/documentation/CONFIG.md
+++ b/documentation/CONFIG.md
@@ -171,7 +171,6 @@ can be forced by using double-quotes ("myTable" is different from mytable).
 ``scylladb.offset.storage.table``
 
   The table within the ScyllaDB keyspace to store the offsets that have been read from Apache Kafka.
-  This is used to enable exactly once delivery to ScyllaDB.
 
   * Type: String
   * Importance: Low
@@ -251,7 +250,7 @@ Also, these topic level configurations will be override the behavior of Connecto
 ``scylladb.offset.storage.table.enable``
 
   If true, Kafka consumer offsets will be stored in ScyllaDB table. If false, connector will skip writing offset 
-  information into ScyllaDB (this might imply duplicate writes into ScyllaDB when a task restarts).
+  information into ScyllaDB.
 
   * Type: Boolean
   * Importance: Medium

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkConnectorConfig.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkConnectorConfig.java
@@ -234,14 +234,13 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
 
   public static final String OFFSET_STORAGE_TABLE_CONF = "scylladb.offset.storage.table";
   private static final String OFFSET_STORAGE_TABLE_DOC = "The table within the Scylladb keyspace "
-          + "to store the offsets that have been read from Kafka. This is used to enable exactly once "
-          + "delivery to ScyllaDb.";
+          + "to store the offsets that have been read from Kafka.";
 
   public static final String ENABLE_OFFSET_STORAGE_TABLE = "scylladb.offset.storage.table.enable";
   private static final Boolean ENABLE_OFFSET_STORAGE_TABLE_DEFAULT = true;
   private static final String ENABLE_OFFSET_STORAGE_TABLE_DOC = "If true, Kafka consumer offsets will "
           + "be stored in Scylladb table. If false, connector will skip writing offset information into "
-          + "Scylladb (this might imply duplicate writes into Scylladb when a task restarts).";
+          + "Scylladb.";
 
   public static final String EXECUTE_STATEMENT_TIMEOUT_MS_CONF = "scylladb.execute.timeout.ms";
   private static final String EXECUTE_STATEMENT_TIMEOUT_MS_DOC = "The timeout for executing a ScyllaDB statement.";


### PR DESCRIPTION
Remove incorrect information about exactly-once semantics of the connector. Even when running with offsets saved to Scylla, there could be a crash between a successful `INSERT` to Scylla and saving of the offset, causing a duplicate `INSERT` after a restart.

Add delivery guarantees section in README, describing that the connector is at-least-once, but how that it might not be relevant in most use cases.

Fixes #44.