### PR TITLE
Override connector validate() method.

### DIFF
--- a/src/main/java/io/connect/scylladb/ScyllaDbSession.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSession.java
@@ -1,6 +1,7 @@
 package io.connect.scylladb;
 
 import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Statement;
@@ -30,6 +31,18 @@ public interface ScyllaDbSession extends Closeable {
      * Execute a query
      */
     ResultSet executeQuery(String query);
+
+    /**
+     * Lookup metadata for a keyspace.
+     * @param keyspaceName name of the keyspace
+     */
+    KeyspaceMetadata keyspaceMetadata(String keyspaceName);
+
+    /**
+     * Check if a keyspace exists.
+     * @param keyspaceName name of the keyspace
+     */
+    boolean keyspaceExists(String keyspaceName);
 
     /**
      * Lookup metadata for a table.

--- a/src/main/java/io/connect/scylladb/ScyllaDbSessionFactory.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSessionFactory.java
@@ -137,7 +137,7 @@ public class ScyllaDbSessionFactory {
     clusterBuilder.withCompression(config.compression);
     Cluster cluster = clusterBuilder.build();
     log.info("Creating session");
-    final Session session = cluster.newSession();
+    final Session session = cluster.connect();
     return new ScyllaDbSessionImpl(config, cluster, session);
   }
 

--- a/src/main/java/io/connect/scylladb/ScyllaDbSessionImpl.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSessionImpl.java
@@ -68,6 +68,17 @@ class ScyllaDbSessionImpl implements ScyllaDbSession {
   }
 
   @Override
+  public KeyspaceMetadata keyspaceMetadata(String keyspaceName){
+    log.trace("keyspaceMetadata() - keyspaceName = '{}'", keyspaceName);
+    return cluster.getMetadata().getKeyspace(keyspaceName);
+  }
+
+  @Override
+  public boolean keyspaceExists(String keyspaceName){
+    return keyspaceMetadata(keyspaceName) != null;
+  }
+
+  @Override
   public TableMetadata.Table tableMetadata(String tableName) {
     log.trace("tableMetadata() - tableName = '{}'", tableName);
     TableMetadata.Table result = this.tableMetadataCache.get(tableName);

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkConnector.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkConnector.java
@@ -152,7 +152,7 @@ public class ScyllaDbSinkConnector extends SinkConnector {
             }
           } else {
             // Check if keyspace exists:
-            if (session.keyspaceExists(config.keyspace)) {
+            if (!session.keyspaceExists(config.keyspace)) {
               keyspaceCreateConfig.addErrorMessage("Seems provided keyspace is not present. Did you mean to set "
                                                    + ScyllaDbSinkConnectorConfig.KEYSPACE_CREATE_ENABLED_CONFIG
                                                    + " to true?");

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkConnector.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkConnector.java
@@ -6,8 +6,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.datastax.driver.core.ResultSet;
 import io.connect.scylladb.utils.VersionUtil;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkConnector;
@@ -103,5 +106,71 @@ public class ScyllaDbSinkConnector extends SinkConnector {
   @Override
   public String version() {
     return VersionUtil.getVersion();
+  }
+
+  @Override
+  public Config validate(Map<String, String> connectorConfigs){
+    // Do the usual validation, field by field.
+    Config result = super.validate(connectorConfigs);
+
+    ConfigValue userConfig = getConfigValue(result, ScyllaDbSinkConnectorConfig.USERNAME_CONFIG);
+    ConfigValue passwordConfig = getConfigValue(result, ScyllaDbSinkConnectorConfig.PASSWORD_CONFIG);
+    if (userConfig.value() == null && passwordConfig.value() != null) {
+      userConfig.addErrorMessage("Username not provided, even though password is.");
+    }
+    if (userConfig.value() != null && passwordConfig.value() == null) {
+      userConfig.addErrorMessage("Password not provided, even though username is.");
+    }
+
+    ConfigValue securityEnable = getConfigValue(result, ScyllaDbSinkConnectorConfig.SECURITY_ENABLE_CONFIG);
+    if (securityEnable.value().equals(true)) {
+      if (userConfig.value() == null) {
+        userConfig.addErrorMessage("Username is required with security enabled.");
+      }
+      if (passwordConfig.value() == null) {
+        passwordConfig.addErrorMessage("Password is required with security enabled.");
+      }
+    }
+
+    boolean hasErrors = result.configValues().stream().anyMatch(c -> !(c.errorMessages().isEmpty()) );
+    if (!hasErrors)
+    {
+      config = new ScyllaDbSinkConnectorConfig(connectorConfigs);
+      // Make trial connection
+      ScyllaDbSessionFactory sessionFactory = new ScyllaDbSessionFactory();
+      try (ScyllaDbSession session = sessionFactory.newSession(config)) {
+        if (!session.isValid()) {
+          ConfigValue contactPoints = getConfigValue(result, ScyllaDbSinkConnectorConfig.CONTACT_POINTS_CONFIG);
+          contactPoints.addErrorMessage("Session is invalid.");
+        } else {
+          ConfigValue keyspaceCreateConfig = getConfigValue(result, ScyllaDbSinkConnectorConfig.KEYSPACE_CREATE_ENABLED_CONFIG);
+          ConfigValue keyspaceConfig = getConfigValue(result, ScyllaDbSinkConnectorConfig.KEYSPACE_CONFIG);
+          if (config.keyspaceCreateEnabled) {
+            if (keyspaceConfig.value() == null) {
+              // This is possibly not needed, since keyspace should be always required non-null.
+              keyspaceConfig.addErrorMessage("Scylla keyspace name is required when keyspace creation is enabled.");
+            }
+          } else {
+            // Check if keyspace exists:
+            if (session.keyspaceExists(config.keyspace)) {
+              keyspaceCreateConfig.addErrorMessage("Seems provided keyspace is not present. Did you mean to set "
+                                                   + ScyllaDbSinkConnectorConfig.KEYSPACE_CREATE_ENABLED_CONFIG
+                                                   + " to true?");
+              keyspaceConfig.addErrorMessage("Keyspace " + config.keyspace + " not found.");
+            }
+          }
+        }
+      } catch (Exception ex) {
+        ConfigValue contactPoints = getConfigValue(result, ScyllaDbSinkConnectorConfig.CONTACT_POINTS_CONFIG);
+        contactPoints.addErrorMessage("Failed to establish trial session: " + ex.getMessage());
+      }
+    }
+    return result;
+  }
+
+  private ConfigValue getConfigValue(Config config, String configName){
+    return config.configValues().stream()
+            .filter(value -> value.name().equals(configName) )
+            .findFirst().get();
   }
 }


### PR DESCRIPTION
Provides custom implementation of validate() method.
Performs some simple cross-checks between different ConfigValues and
makes a trial connection with the database.