### PR TITLE
Add configuration for integration testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   zookeeper:
     image: confluentinc/cp-zookeeper:3.2.2
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_CLIENT_PORT: "2181"
       zk_id: "1"
     ports:
       - "2181:2181"
@@ -27,7 +27,7 @@ services:
       - "8081:8081"
     environment:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: "zookeeper:2181"
-      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_HOST_NAME: "schema-registry"
   scylladb:
     image: scylladb/scylla
     hostname: scylladb/scylla

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,8 @@
         <license.current.year>2020</license.current.year>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <junit.surefire.plugin.version>1.2.0</junit.surefire.plugin.version>
-        <failsafe.version>2.21.0</failsafe.version>
+        <surefire.version>3.0.0-M5</surefire.version>
+        <failsafe.version>3.0.0-M5</failsafe.version>
         <kafka.version>2.4.0</kafka.version>
         <junit.version>5.2.0</junit.version>
         <scylladb.version>3.7.1-scylla-2</scylladb.version>
@@ -87,6 +88,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
                 <configuration>
                     <excludedGroups>org.apache.kafka.test.IntegrationTest</excludedGroups>
                 </configuration>
@@ -95,21 +97,18 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${failsafe.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>${junit.surefire.plugin.version}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <skip>${skipIntegrationTests}</skip>
-                    <groups>org.apache.kafka.test.IntegrationTest</groups>
+                    <includes>**/*IT.java</includes>
+                    <systemPropertyVariables>
+                        <scylla.docker.hostname>${docker.host.address}</scylla.docker.hostname>
+                    </systemPropertyVariables>
                 </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -128,6 +127,51 @@
                         <phase>test</phase>
                         <goals>
                             <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.39.0</version>
+
+                <configuration>
+                    <imagePullPolicy>Always</imagePullPolicy>
+                    <images>
+                        <image>
+                            <alias>composeImages</alias>
+                            <name>fabric8/compose-demo:latest</name>
+                            <external>
+                                <type>compose</type>
+                                <basedir>${basedir}</basedir>
+                                <composeFile>docker-compose.yml</composeFile>
+                            </external>
+                            <run>
+                                <wait>
+                                    <!-- Wait for Scylla and other containers to start up. -->
+                                    <log>init - serving</log>
+                                    <time>90000</time>
+                                </wait>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <id>start</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/main/java/io/connect/scylladb/ScyllaDbSessionImpl.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSessionImpl.java
@@ -136,7 +136,7 @@ class ScyllaDbSessionImpl implements ScyllaDbSession {
     Insert statement = QueryBuilder.insertInto(config.keyspace, tableName);
     TableMetadata.Table tableMetadata = tableMetadata(tableName);
     for (TableMetadata.Column columnMetadata : tableMetadata.columns()) {
-      statement.value(columnMetadata.getName(), QueryBuilder.bindMarker(columnMetadata.getName()));
+      statement.value(QueryBuilder.quote(columnMetadata.getName()), QueryBuilder.bindMarker(columnMetadata.getName()));
     }
     log.debug("insert() - Preparing statement. '{}'", statement);
     if (topicConfigs != null) {

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkConnectorConfig.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkConnectorConfig.java
@@ -269,7 +269,7 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
 
   public static final String TTL_CONFIG = "scylladb.ttl";
   /*If TTL value is not specified then skip setting ttl value while making insert query*/
-  public static final String TTL_DEFAULT = null;
+  public static final Integer TTL_DEFAULT = null;
   private static final String TTL_DOC = "The retention period for the data in ScyllaDB. "
           + "After this interval elapses, Scylladb will remove these records. "
           + "If this configuration is not provided, the Sink Connector will perform "
@@ -570,7 +570,7 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
                     "Execute statement timeout (in ms)")
             .define(
                     TTL_CONFIG,
-                    ConfigDef.Type.STRING,
+                    ConfigDef.Type.INT,
                     TTL_DEFAULT,
                     ConfigDef.Importance.MEDIUM,
                     TTL_DOC,

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkTask.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkTask.java
@@ -59,8 +59,8 @@ public class ScyllaDbSinkTask extends SinkTask {
       if (!offsets.isEmpty()) {
         context.offset(offsets);
       }
-      topicOffsets = new HashMap<>();
     }
+    topicOffsets = new HashMap<>();
   }
 
   /*


### PR DESCRIPTION
Adds docker-maven-plugin with configuration that uses preexisting compose file.
Bumps verisions of maven-surefire-plugin and maven-failsafe-plugin.
Removes 1 dependency due to its issues with integration-test goal.
Minor fixes due to small bugs like Integer to String conversion errors.