### PR TITLE
Skip unnecessary docker containers creation.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,34 @@
 
 version: "2"
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:3.2.2
-    environment:
-      ZOOKEEPER_CLIENT_PORT: "2181"
-      zk_id: "1"
-    ports:
-      - "2181:2181"
-  kafka:
-    hostname: kafka
-    image: confluentinc/cp-kafka:3.2.2
-    links:
-      - zookeeper
-    ports:
-      - "9092:9092"
-    environment:
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://:9092"
-  schema-registry:
-    image: confluentinc/cp-schema-registry:3.2.2
-    links:
-      - kafka
-      - zookeeper
-    ports:
-      - "8081:8081"
-    environment:
-      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: "zookeeper:2181"
-      SCHEMA_REGISTRY_HOST_NAME: "schema-registry"
+  # for future e2e testing
+  #  zookeeper:
+  #    image: confluentinc/cp-zookeeper:3.2.2
+  #    environment:
+  #      ZOOKEEPER_CLIENT_PORT: "2181"
+  #      zk_id: "1"
+  #    ports:
+  #      - "2181:2181"
+  #  kafka:
+  #    hostname: kafka
+  #    image: confluentinc/cp-kafka:3.2.2
+  #    links:
+  #      - zookeeper
+  #    ports:
+  #      - "9092:9092"
+  #    environment:
+  #      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+  #      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://:9092"
+  #  schema-registry:
+  #    image: confluentinc/cp-schema-registry:3.2.2
+  #    links:
+  #      - kafka
+  #      - zookeeper
+  #    ports:
+  #      - "8081:8081"
+  #    environment:
+  #      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: "zookeeper:2181"
+  #      SCHEMA_REGISTRY_HOST_NAME: "schema-registry"
   scylladb:
     image: scylladb/scylla
     hostname: scylladb/scylla


### PR DESCRIPTION
Current docker-compose has some images set up for future e2e testing,
but as they are not used right now they give a false impression that
some actual e2e testing is happening and waste time by having to pull
and setup the images.