### PR TITLE
Bump dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <kafka.version>2.4.0</kafka.version>
         <junit.version>5.2.0</junit.version>
         <scylladb.version>3.7.1-scylla-2</scylladb.version>
-        <netty.version>4.1.45.Final</netty.version>
+        <netty.version>4.1.77.Final</netty.version>
         <netty-tcnative.version>2.0.7.Final</netty-tcnative.version>
         <skipIntegrationTests>false</skipIntegrationTests>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <failsafe.version>3.0.0-M5</failsafe.version>
         <kafka.version>2.4.0</kafka.version>
         <junit.version>5.2.0</junit.version>
-        <scylladb.version>3.7.1-scylla-2</scylladb.version>
+        <scylladb.version>3.11.2.0</scylladb.version>
         <netty.version>4.1.77.Final</netty.version>
         <netty-tcnative.version>2.0.7.Final</netty-tcnative.version>
         <skipIntegrationTests>false</skipIntegrationTests>

--- a/src/main/java/io/connect/scylladb/ScyllaDbSessionFactory.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSessionFactory.java
@@ -55,7 +55,7 @@ public class ScyllaDbSessionFactory {
 
   public ScyllaDbSession newSession(ScyllaDbSinkConnectorConfig config) {
     Cluster.Builder clusterBuilder = Cluster.builder()
-        .withProtocolVersion(ProtocolVersion.NEWEST_SUPPORTED)
+        .withProtocolVersion(ProtocolVersion.DEFAULT)
         .withCodecRegistry(CODEC_REGISTRY);
 
     try {

--- a/src/test/java/io/connect/scylladb/integration/ScyllaDbSinkConnectorIT.java
+++ b/src/test/java/io/connect/scylladb/integration/ScyllaDbSinkConnectorIT.java
@@ -58,7 +58,7 @@ public class ScyllaDbSinkConnectorIT {
     Cluster.Builder clusterBuilder = Cluster.builder()
             .withPort(SCYLLA_DB_PORT)
             .addContactPoints(SCYLLA_DB_CONTACT_POINT)
-            .withProtocolVersion(ProtocolVersion.NEWEST_SUPPORTED);
+            .withProtocolVersion(ProtocolVersion.DEFAULT);
     return clusterBuilder;
   }
 

--- a/src/test/java/io/connect/scylladb/integration/ScyllaNativeTypesIT.java
+++ b/src/test/java/io/connect/scylladb/integration/ScyllaNativeTypesIT.java
@@ -68,7 +68,7 @@ public class ScyllaNativeTypesIT {
         Cluster.Builder clusterBuilder = Cluster.builder()
                 .withPort(SCYLLA_DB_PORT)
                 .addContactPoints(SCYLLA_DB_CONTACT_POINT)
-                .withProtocolVersion(ProtocolVersion.NEWEST_SUPPORTED);
+                .withProtocolVersion(ProtocolVersion.DEFAULT);
         return clusterBuilder;
     }
 

--- a/src/test/java/io/connect/scylladb/integration/codec/StringTimeUuidCodecTest.java
+++ b/src/test/java/io/connect/scylladb/integration/codec/StringTimeUuidCodecTest.java
@@ -79,13 +79,13 @@ class StringTimeUuidCodecTest {
   @Test
   public void shouldFailToSerializeNonUuidString() {
     Assertions.assertThrows(InvalidTypeException.class, () -> {
-      codec.serialize(NON_UUID_STR, ProtocolVersion.NEWEST_SUPPORTED);
+      codec.serialize(NON_UUID_STR, ProtocolVersion.DEFAULT);
     });
   }
 
   protected void assertSerializeAndDeserialize(String uuidStr) {
-    ByteBuffer buffer = codec.serialize(uuidStr, ProtocolVersion.NEWEST_SUPPORTED);
-    String deserialized = codec.deserialize(buffer, ProtocolVersion.NEWEST_SUPPORTED);
+    ByteBuffer buffer = codec.serialize(uuidStr, ProtocolVersion.DEFAULT);
+    String deserialized = codec.deserialize(buffer, ProtocolVersion.DEFAULT);
     assertEquals(uuidStr, deserialized);
   }
 }

--- a/src/test/java/io/connect/scylladb/integration/codec/StringUuidCodecTest.java
+++ b/src/test/java/io/connect/scylladb/integration/codec/StringUuidCodecTest.java
@@ -70,13 +70,13 @@ class StringUuidCodecTest {
   @Test
   public void shouldFailToSerializeNonUuidString() {
     Assertions.assertThrows(InvalidTypeException.class, () -> {
-      codec.serialize(NON_UUID_STR, ProtocolVersion.NEWEST_SUPPORTED);
+      codec.serialize(NON_UUID_STR, ProtocolVersion.DEFAULT);
     });
   }
 
   protected void assertSerializeAndDeserialize(String uuidStr) {
-    ByteBuffer buffer = codec.serialize(uuidStr, ProtocolVersion.NEWEST_SUPPORTED);
-    String deserialized = codec.deserialize(buffer, ProtocolVersion.NEWEST_SUPPORTED);
+    ByteBuffer buffer = codec.serialize(uuidStr, ProtocolVersion.DEFAULT);
+    String deserialized = codec.deserialize(buffer, ProtocolVersion.DEFAULT);
     assertEquals(uuidStr, deserialized);
   }
 }


### PR DESCRIPTION
Bumps netty to earliest higher version without any vulnerabilities reported by automated checks.
Bumps java driver to highest version found at mvnrepository.
Some tests required setting different protocol version constant, 
because newest protocol supported by driver goes ahead of newest supported by Scylla docker image.