### PR TITLE
Support mapping Kafka topic names to arbitrary table names in Scylla.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ generate a primary key for the table when it is created. These fields must also 
 written to the table is always read from the value from Apache Kafka. This connector uses the topic to determine the name of
 the table to write to. This can be changed on the fly by using a transform to change the topic name.
 
+Note that when schema management is enabled, Invalid kafka topic names will be rewritten to valid Scylla table names. Specifically,
+"." and "-" in topic names will be replaced with "_".
+
 --------------------------
 Time To Live (TTL) Support
 --------------------------

--- a/config/scylladb-sink-quickstart.properties
+++ b/config/scylladb-sink-quickstart.properties
@@ -51,6 +51,11 @@ scylladb.keyspace=<keyspace-name>
 #topic.my_topic.my_ks.my_table.ttlSeconds=1
 #topic.my_topic.my_ks.my_table.deletesEnabled=true
 
+### Mapping topic names to arbitrary table names
+# Format is topic2tablename.<name of kafka topic>: <name of Scylla table>
+# topic2tablename.topic1-staging: completely_different_tablename
+# topic2tablename.topic2-staging: completely_different_Tablename3
+
 ### Writer configs
 #scylladb.consistency.level=LOCAL_QUORUM
 #scylladb.deletes.enabled=true

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkTaskHelper.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkTaskHelper.java
@@ -48,8 +48,9 @@ public class ScyllaDbSinkTaskHelper {
     }
   }
 
+
   public BoundStatement getBoundStatementForRecord(SinkRecord record) {
-    final String tableName = record.topic().replaceAll("\\.", "_").replaceAll("-", "_");
+    final String tableName = scyllaDbSinkConnectorConfig.getTableName(record.topic());
     BoundStatement boundStatement = null;
     TopicConfigs topicConfigs = null;
     if (scyllaDbSinkConnectorConfig.topicWiseConfigs.containsKey(tableName)) {

--- a/src/test/java/io/connect/scylladb/ScyllaDbSinkConnectorConfigTest.java
+++ b/src/test/java/io/connect/scylladb/ScyllaDbSinkConnectorConfigTest.java
@@ -41,5 +41,29 @@ public class ScyllaDbSinkConnectorConfigTest {
     new ScyllaDbSinkConnectorConfig(settings);
   }
 
+  @Test
+  public void testTableName() {
+    config = new ScyllaDbSinkConnectorConfig(settings);
+    assertEquals("test", config.getTableName("test"));
+    assertEquals("topic_with_hyphen", config.getTableName("topic-with-hyphen"));
+    assertEquals("topic_with_dot", config.getTableName("topic.with.dot"));
+  }
+
+  @Test
+  public void testReplaceTableName() {
+    settings.put("topic2tablename.test-topic", "tablename");
+    config = new ScyllaDbSinkConnectorConfig(settings);
+    assertEquals("test", config.getTableName("test"));
+    assertEquals("tablename", config.getTableName("test-topic"));
+  }
+
+  @Test
+  public void testTopicSettings() {
+    settings.put("topic.topic-name.keyspace.tablename.ttlSeconds", "3600");
+    config = new ScyllaDbSinkConnectorConfig(settings);
+    assertEquals(Integer.valueOf(3600), config.topicWiseConfigs.get("topic-name").getTtl());
+
+  }
+
   //TODO: Add more tests
 }


### PR DESCRIPTION
This is done via a new configuration mapping, "topic2tablename".

Also rewrites illegal tables names (with "-" or ".") by replacing the illegal charaters with underscore ("_").