### PR TITLE
Always return preCommit's currentOffsets

### DIFF
--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkTask.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkTask.java
@@ -176,14 +176,7 @@ public class ScyllaDbSinkTask extends SinkTask {
         throw new RetriableException(ex);
       }
     }
-    if (!topicOffsets.isEmpty()) {
-      return topicOffsets;
-    } else {
-      /*
-       * In case when @put is empty, returning the same offsets
-       */
-      return currentOffsets;
-    }
+    return currentOffsets;
   }
 
   /**


### PR DESCRIPTION
Currently all Kafka Sink connectors receive records after transformations inside `put()` calls. This poses a problem when information about original record is required. In such case we have to default to Kafka's offset tracking instead of our own because we cannot determine the original topic of the record.