### PR TITLE
Remove org.json dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,12 +273,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20160810</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-runtime</artifactId>
             <version>${kafka.version}</version>

--- a/src/main/java/io/connect/scylladb/ClusterAddressTranslator.java
+++ b/src/main/java/io/connect/scylladb/ClusterAddressTranslator.java
@@ -31,7 +31,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import org.json.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,29 +47,13 @@ class ClusterAddressTranslator implements AddressTranslator {
     public void init(Cluster cluster) {
     }
 
-    public void setMap(String addressMapString) {
-        JSONObject jsonmap;
-
-        if (addressMapString.charAt(0) == '[') {
-            JSONArray jsonarray = new JSONArray(addressMapString);
-            log.trace("Address translation map: " + jsonarray.toString());
-            Iterator jai = jsonarray.iterator();
-
-            while (jai.hasNext()) {
-                JSONObject element = (JSONObject) jai.next();
-                Iterator subpart = element.keys();
-                String internal = (String) subpart.next();
-                String external = element.getString(internal);
-                addAddresses(internal, external);
-            }
-        } else {
-            jsonmap = new JSONObject(addressMapString);
-            Iterator keys = jsonmap.keys();
-            while (keys.hasNext()) {
-                String internal = (String) keys.next();
-                String external = (String) jsonmap.getString(internal);
-                addAddresses(internal, external);
-            }
+    public void setMap(String addressMapString) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(addressMapString);
+        Iterator<Map.Entry<String, JsonNode>> entries = jsonNode.fields();
+        while(entries.hasNext()) {
+            Map.Entry<String, JsonNode> entry = entries.next();
+            addAddresses(entry.getKey(), entry.getValue().asText());
         }
     }
 

--- a/src/main/java/io/connect/scylladb/ScyllaDbSessionFactory.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSessionFactory.java
@@ -8,6 +8,7 @@ import com.datastax.driver.core.SSLOptions;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.extras.codecs.date.SimpleDateCodec;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.connect.scylladb.codec.ConvenienceCodecs;
 import io.connect.scylladb.codec.StringDurationCodec;
 import io.connect.scylladb.codec.StringInetCodec;
@@ -17,8 +18,6 @@ import io.connect.scylladb.codec.StringVarintCodec;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.json.JSONObject;
-import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +59,7 @@ public class ScyllaDbSessionFactory {
 
     try {
       configureAddressTranslator(config, clusterBuilder);
-    } catch (JSONException e) {
+    } catch (JsonProcessingException e) {
       log.info("Failed to configure address translator, provide a valid JSON string " +
               "with external network address and port mapped to private network " +
               "address and port.");
@@ -158,9 +157,8 @@ public class ScyllaDbSessionFactory {
             .addContactPoints(contactPointsArray);
   }
 
-  private void configureAddressTranslator(ScyllaDbSinkConnectorConfig config, Cluster.Builder clusterBuilder) {
+  private void configureAddressTranslator(ScyllaDbSinkConnectorConfig config, Cluster.Builder clusterBuilder) throws JsonProcessingException {
     log.info("Trying to configure address translator for private network address and port.");
-    new JSONObject(config.contactPoints);
     ClusterAddressTranslator translator = new ClusterAddressTranslator();
     translator.setMap(config.contactPoints);
     clusterBuilder.addContactPointsWithPorts(translator.getContactPoints())

--- a/src/test/java/io/connect/scylladb/ClusterAddressTranslatorTest.java
+++ b/src/test/java/io/connect/scylladb/ClusterAddressTranslatorTest.java
@@ -1,0 +1,16 @@
+package io.connect.scylladb;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.Test;
+
+public class ClusterAddressTranslatorTest {
+
+  @Test
+  public void setMapTest() throws JsonProcessingException {
+    ClusterAddressTranslator addressTranslator = new ClusterAddressTranslator();
+    final String ADDRESS_MAP_STRING = "{\"10.0.24.69:9042\": \"sl-eu-lon-2-portal.3.dblayer.com:15227\", "
+        + "\"10.0.24.71:9042\": \"sl-eu-lon-2-portal.2.dblayer.com:15229\", "
+        + "\"10.0.24.70:9042\": \"sl-eu-lon-2-portal.1.dblayer.com:15228\"}"; // String from CONTACT_POINTS_DOC
+    addressTranslator.setMap(ADDRESS_MAP_STRING);
+  }
+}


### PR DESCRIPTION
This dependency in its current version introduces a vulnerability. As it is used only in one place and there are other JSON processing dependencies added already I'm using this opportunity to remove org.json:json.

Changes include:
- Removal of org.json from pom.xml
- Rewrite of ClusterAddressTranslator.setMap(String addressMapString)
- Addition of unit test of ClusterAddressTranslator.setMap(String addressMapString)