### PR TITLE
Switch to driver version 4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,7 @@
         <failsafe.version>3.0.0-M5</failsafe.version>
         <kafka.version>2.4.0</kafka.version>
         <junit.version>5.2.0</junit.version>
-        <scylladb.version>3.11.2.0</scylladb.version>
-        <netty.version>4.1.77.Final</netty.version>
-        <netty-tcnative.version>2.0.7.Final</netty-tcnative.version>
+        <scylladb.version>4.17.0.0</scylladb.version>
         <skipIntegrationTests>false</skipIntegrationTests>
         <!-- transitive dependency versions -->
         <jackson-databind.version>2.13.4.2</jackson-databind.version>
@@ -95,6 +93,7 @@
                 <version>${surefire.version}</version>
                 <configuration>
                     <excludedGroups>org.apache.kafka.test.IntegrationTest</excludedGroups>
+                    <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>
             <plugin>
@@ -102,6 +101,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${failsafe.version}</version>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
                     <skip>${skipIntegrationTests}</skip>
                     <includes>**/*IT.java</includes>
                     <systemPropertyVariables>
@@ -197,11 +197,6 @@
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson-databind.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -230,46 +225,20 @@
 
         <dependency>
             <groupId>com.scylladb</groupId>
-            <artifactId>scylla-driver-core</artifactId>
+            <artifactId>java-driver-core</artifactId>
             <version>${scylladb.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-handler</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-transport-native-epoll</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-tcnative</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.scylladb</groupId>
-            <artifactId>scylla-driver-extras</artifactId>
-            <version>3.11.0.1</version>
+            <artifactId>java-driver-query-builder</artifactId>
+            <version>${scylladb.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-epoll</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative</artifactId>
-            <version>${netty-tcnative.version}</version>
+            <groupId>com.scylladb</groupId>
+            <artifactId>java-driver-mapper-runtime</artifactId>
+            <version>${scylladb.version}</version>
         </dependency>
 
         <dependency>
@@ -316,6 +285,21 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <!-- should match version from drivers POM -->
+            <version>1.7.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <!-- should match version from drivers POM -->
+            <version>1.1.10.1</version>
+        </dependency>
+
 
         <!-- TODO: Dependency for Integration test -->
         <!--dependency>

--- a/src/main/java/io/connect/scylladb/ClusterAddressTranslator.java
+++ b/src/main/java/io/connect/scylladb/ClusterAddressTranslator.java
@@ -23,8 +23,6 @@
 
 package io.connect.scylladb;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.policies.AddressTranslator;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Collections;
@@ -32,6 +30,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,10 +41,6 @@ class ClusterAddressTranslator implements AddressTranslator {
 
     public Map<InetSocketAddress, InetSocketAddress> addressMap = new HashMap<>();
     private static final Logger log = LoggerFactory.getLogger(ClusterAddressTranslator.class);
-
-    @Override
-    public void init(Cluster cluster) {
-    }
 
     public void setMap(String addressMapString) throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/io/connect/scylladb/RecordConverter.java
+++ b/src/main/java/io/connect/scylladb/RecordConverter.java
@@ -1,6 +1,6 @@
 package io.connect.scylladb;
 
-import com.google.common.base.Preconditions;
+import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
 import io.connect.scylladb.topictotable.TopicConfigs;
 import io.connect.scylladb.utils.ScyllaDbConstants;
 import org.apache.kafka.connect.data.Field;

--- a/src/main/java/io/connect/scylladb/RecordToBoundStatementConverter.java
+++ b/src/main/java/io/connect/scylladb/RecordToBoundStatementConverter.java
@@ -1,13 +1,15 @@
 package io.connect.scylladb;
 
-import com.datastax.driver.core.BoundStatement;
-import com.datastax.driver.core.LocalDate;
-import com.datastax.driver.core.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -18,7 +20,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
 
   static class State {
 
-    public final BoundStatement statement;
+    public BoundStatement statement;
     public int parameters = 0;
 
     State(BoundStatement statement) {
@@ -40,7 +42,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       String fieldName,
       String value
   ) {
-    state.statement.setString(fieldName, value);
+    state.statement = state.statement.setString(fieldName, value);
     state.parameters++;
   }
 
@@ -49,7 +51,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       String fieldName,
       Float value
   ) {
-    state.statement.setFloat(fieldName, value);
+    state.statement = state.statement.setFloat(fieldName, value);
     state.parameters++;
   }
 
@@ -58,7 +60,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       String fieldName,
       Double value
   ) {
-    state.statement.setDouble(fieldName, value);
+    state.statement = state.statement.setDouble(fieldName, value);
     state.parameters++;
   }
 
@@ -67,7 +69,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       String fieldName,
       Date value
   ) {
-    state.statement.setTimestamp(fieldName, value);
+    state.statement = state.statement.setInstant(fieldName, value.toInstant());
     state.parameters++;
   }
 
@@ -76,7 +78,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       String fieldName,
       Date value
   ) {
-    state.statement.setDate(fieldName, LocalDate.fromMillisSinceEpoch(value.getTime()));
+    state.statement = state.statement.setLocalDate(fieldName, LocalDate.from(value.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()));
     state.parameters++;
   }
 
@@ -85,8 +87,9 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       String fieldName,
       Date value
   ) {
-    final long nanoseconds = TimeUnit.MILLISECONDS.convert(value.getTime(), TimeUnit.NANOSECONDS);
-    state.statement.setTime(fieldName, nanoseconds);
+    final long nanoseconds = TimeUnit.NANOSECONDS.convert(value.getTime(), TimeUnit.MILLISECONDS);
+    state.statement = state.statement.setLocalTime(fieldName, LocalTime.ofNanoOfDay(nanoseconds));
+
     state.parameters++;
   }
 
@@ -95,7 +98,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       String fieldName,
       Byte value
   ) {
-    state.statement.setByte(fieldName, value);
+    state.statement = state.statement.setByte(fieldName, value);
     state.parameters++;
   }
 
@@ -104,7 +107,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       String fieldName,
       Short value
   ) {
-    state.statement.setShort(fieldName, value);
+    state.statement = state.statement.setShort(fieldName, value);
     state.parameters++;
   }
 
@@ -113,7 +116,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       String fieldName,
       Integer value
   ) {
-    state.statement.setInt(fieldName, value);
+    state.statement = state.statement.setInt(fieldName, value);
     state.parameters++;
   }
 
@@ -122,7 +125,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       String fieldName,
       Long value
   ) {
-    state.statement.setLong(fieldName, value);
+    state.statement = state.statement.setLong(fieldName, value);
     state.parameters++;
   }
 
@@ -131,7 +134,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       String fieldName,
       byte[] value
   ) {
-    state.statement.setBytes(fieldName, ByteBuffer.wrap(value));
+    state.statement = state.statement.setByteBuffer(fieldName, ByteBuffer.wrap(value));
     state.parameters++;
   }
 
@@ -140,7 +143,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       String fieldName,
       BigDecimal value
   ) {
-    state.statement.setDecimal(fieldName, value);
+    state.statement = state.statement.setBigDecimal(fieldName, value);
     state.parameters++;
   }
 
@@ -149,7 +152,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       String fieldName,
       Boolean value
   ) {
-    state.statement.setBool(fieldName, value);
+    state.statement = state.statement.setBool(fieldName, value);
     state.parameters++;
   }
 
@@ -167,7 +170,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       Schema schema,
       List value
   ) {
-    state.statement.setList(fieldName, value);
+    state.statement = state.statement.setList(fieldName, value, Object.class);
     state.parameters++;
   }
 
@@ -177,7 +180,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       Schema schema,
       Map value
   ) {
-    state.statement.setMap(fieldName, value);
+    state.statement = state.statement.setMap(fieldName, value, Object.class, Object.class);
     state.parameters++;
   }
 
@@ -185,7 +188,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       RecordToBoundStatementConverter.State state,
       String fieldName
   ) {
-    state.statement.setToNull(fieldName);
+    state.statement = state.statement.setToNull(fieldName);
     state.parameters++;
   }
 }

--- a/src/main/java/io/connect/scylladb/ScyllaDbSession.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSession.java
@@ -1,19 +1,19 @@
 package io.connect.scylladb;
 
-import com.datastax.driver.core.BoundStatement;
-import com.datastax.driver.core.KeyspaceMetadata;
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.ResultSetFuture;
-import com.datastax.driver.core.Statement;
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Statement;
+import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import io.connect.scylladb.topictotable.TopicConfigs;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.io.Closeable;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletionStage;
 
 public interface ScyllaDbSession extends Closeable {
 
@@ -25,7 +25,7 @@ public interface ScyllaDbSession extends Closeable {
     /**
      * Execute a statement asynchronously
      */
-    ResultSetFuture executeStatementAsync(Statement statement);
+    CompletionStage<AsyncResultSet> executeStatementAsync(Statement statement);
 
     /**
      * Execute a query

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkConnector.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkConnector.java
@@ -7,7 +7,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import com.datastax.driver.core.ResultSet;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
+import com.datastax.oss.driver.api.querybuilder.schema.CreateKeyspace;
+import com.datastax.oss.driver.api.querybuilder.schema.CreateTable;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import io.connect.scylladb.utils.VersionUtil;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.Config;
@@ -17,12 +21,6 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.schemabuilder.Create;
-import com.datastax.driver.core.schemabuilder.KeyspaceOptions;
-import com.datastax.driver.core.schemabuilder.SchemaBuilder;
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Sink connector class for Scylla Database.
@@ -52,24 +50,23 @@ public class ScyllaDbSinkConnector extends SinkConnector {
     try (ScyllaDbSession session = sessionFactory.newSession(config)) {
 
       if (config.keyspaceCreateEnabled) {
-        KeyspaceOptions createKeyspace = SchemaBuilder.createKeyspace(config.keyspace)
+        CreateKeyspace createKeyspace = SchemaBuilder.createKeyspace(config.keyspace)
                 .ifNotExists()
-                .with()
-                .durableWrites(true)
-                .replication(ImmutableMap.of(
-                        "class", (Object) "SimpleStrategy",
-                        "replication_factor", config.keyspaceReplicationFactor
-                ));
-        session.executeStatement(createKeyspace);
+                .withReplicationOptions(ImmutableMap.of(
+                "class", (Object) "SimpleStrategy",
+                "replication_factor", config.keyspaceReplicationFactor
+                  ))
+            .withDurableWrites(true);
+        session.executeStatement(createKeyspace.build());
       }
       if (config.offsetEnabledInScyllaDB) {
-        final Create createOffsetStorage = SchemaBuilder
+        final CreateTable createOffsetStorage = SchemaBuilder
                 .createTable(config.keyspace, config.offsetStorageTable)
-                .addPartitionKey("topic", DataType.varchar())
-                .addPartitionKey("partition", DataType.cint())
-                .addColumn("offset", DataType.bigint())
-                .ifNotExists();
-        session.executeStatement(createOffsetStorage);
+                .ifNotExists()
+                .withPartitionKey("topic", DataTypes.TEXT)
+                .withPartitionKey("partition", DataTypes.INT)
+                .withColumn("offset", DataTypes.BIGINT);
+        session.executeStatement(createOffsetStorage.build());
       }
 
     } catch (IOException ex) {
@@ -164,6 +161,7 @@ public class ScyllaDbSinkConnector extends SinkConnector {
       } catch (Exception ex) {
         ConfigValue contactPoints = getConfigValue(result, ScyllaDbSinkConnectorConfig.CONTACT_POINTS_CONFIG);
         contactPoints.addErrorMessage("Failed to establish trial session: " + ex.getMessage());
+        log.error("Validation ended with exception", ex);
       }
     }
     return result;

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkConnectorConfig.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkConnectorConfig.java
@@ -6,28 +6,25 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
+import com.datastax.oss.driver.shaded.guava.common.base.Strings;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableSet;
 import io.connect.scylladb.utils.ListRecommender;
 import io.connect.scylladb.utils.NullOrReadableFile;
 import io.connect.scylladb.utils.VisibleIfEqual;
 import org.apache.kafka.common.config.AbstractConfig;
-import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 
-import com.datastax.driver.core.ConsistencyLevel;
-import com.datastax.driver.core.ProtocolOptions;
-import com.datastax.driver.core.schemabuilder.SchemaBuilder;
-import com.datastax.driver.core.schemabuilder.TableOptions;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 
 import io.confluent.kafka.connect.utils.config.ConfigUtils;
 import io.confluent.kafka.connect.utils.config.ValidEnum;
 import io.confluent.kafka.connect.utils.config.ValidPort;
 import io.connect.scylladb.topictotable.TopicConfigs;
-import io.netty.handler.ssl.SslProvider;
 
 /**
  * Configuration class for {@link ScyllaDbSinkConnector}.
@@ -40,16 +37,16 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
   public final boolean securityEnabled;
   public final String username;
   public final String password;
-  public final ProtocolOptions.Compression compression;
+  public final String compression;
   public final boolean sslEnabled;
-  public final SslProvider sslProvider;
+  public final boolean sslHostnameVerificationEnabled;
   public final boolean deletesEnabled;
   public final String keyspace;
   public final boolean keyspaceCreateEnabled;
   public final int keyspaceReplicationFactor;
   public final boolean offsetEnabledInScyllaDB;
   public final boolean tableManageEnabled;
-  public final TableOptions.CompressionOptions tableCompressionAlgorithm;
+  public final String tableCompressionAlgorithm;
   public final char[] trustStorePassword;
   public final File trustStorePath;
   public final char[] keyStorePassword;
@@ -61,37 +58,26 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
   public final Integer ttl;
   public final BehaviorOnError behaviourOnError;
   public final List<String> cipherSuites;
-  public final File certFilePath;
-  public final File privateKeyPath;
 
   private static final Pattern TOPIC_KS_TABLE_SETTING_PATTERN =
           Pattern.compile("topic\\.([a-zA-Z0-9._-]+)\\.([^.]+|\"[\"]+\")\\.([^.]+|\"[\"]+\")\\.(mapping|consistencyLevel|ttlSeconds|deletesEnabled)$");
 
-  static final Map<String, ProtocolOptions.Compression> CLIENT_COMPRESSION =
-      ImmutableMap.of(
-          "NONE", ProtocolOptions.Compression.NONE,
-          "SNAPPY", ProtocolOptions.Compression.SNAPPY,
-          "LZ4", ProtocolOptions.Compression.LZ4
-      );
+  static final Set<String> CLIENT_COMPRESSION = ImmutableSet.of("none", "lz4", "snappy");
 
-  static final Map<String, TableOptions.CompressionOptions.Algorithm> TABLE_COMPRESSION =
-      ImmutableMap.of(
-          "NONE", TableOptions.CompressionOptions.Algorithm.NONE,
-          "SNAPPY", TableOptions.CompressionOptions.Algorithm.SNAPPY,
-          "LZ4", TableOptions.CompressionOptions.Algorithm.LZ4,
-          "DEFLATE", TableOptions.CompressionOptions.Algorithm.DEFLATE
-      );
+  static final Set<String> TABLE_COMPRESSORS = ImmutableSet.of("SnappyCompressor", "LZ4Compressor", "DeflateCompressor", "none");
+
 
   public ScyllaDbSinkConnectorConfig(Map<?, ?> originals) {
     super(config(), originals);
     this.port = getInt(PORT_CONFIG);
     this.contactPoints = getString(CONTACT_POINTS_CONFIG);
     this.consistencyLevel =
-            ConfigUtils.getEnum(ConsistencyLevel.class, this, CONSISTENCY_LEVEL_CONFIG);
+            ConfigUtils.getEnum(DefaultConsistencyLevel.class, this, CONSISTENCY_LEVEL_CONFIG);
     this.username = getString(USERNAME_CONFIG);
     this.password = getPassword(PASSWORD_CONFIG) == null ? null : getPassword(PASSWORD_CONFIG).value();
     this.securityEnabled = getBoolean(SECURITY_ENABLE_CONFIG);
     this.sslEnabled = getBoolean(SSL_ENABLED_CONFIG);
+    this.sslHostnameVerificationEnabled = getBoolean(SSL_HOSTNAME_VERIFICATION_CONFIG);
     this.deletesEnabled = getBoolean(DELETES_ENABLE_CONFIG);
 
     this.keyspace = getString(KEYSPACE_CONFIG);
@@ -109,37 +95,13 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
 
     this.cipherSuites = getList(SSL_CIPHER_SUITES_CONFIG);
 
-    final String certFilePath = this.getString(SSL_OPENSLL_KEYCERTCHAIN_CONFIG);
-    this.certFilePath = Strings.isNullOrEmpty(certFilePath) ? null : new File(certFilePath);
-    final String privateKeyPath = this.getString(SSL_OPENSLL_PRIVATEKEY_CONFIG);
-    this.privateKeyPath = Strings.isNullOrEmpty(privateKeyPath) ? null : new File(privateKeyPath);
-
     final String compression = getString(COMPRESSION_CONFIG);
-    this.compression = CLIENT_COMPRESSION.get(compression);
-    this.sslProvider = ConfigUtils.getEnum(SslProvider.class, this, SSL_PROVIDER_CONFIG);
+    this.compression = compression;
     this.keyspaceCreateEnabled = getBoolean(KEYSPACE_CREATE_ENABLED_CONFIG);
     this.offsetEnabledInScyllaDB = getBoolean(ENABLE_OFFSET_STORAGE_TABLE);
     this.keyspaceReplicationFactor = getInt(KEYSPACE_REPLICATION_FACTOR_CONFIG);
     this.tableManageEnabled = getBoolean(TABLE_MANAGE_ENABLED_CONFIG);
-    TableOptions.CompressionOptions.Algorithm tableCompressionAlgo = ConfigUtils.getEnum(
-            TableOptions.CompressionOptions.Algorithm.class,
-            this,
-            TABLE_CREATE_COMPRESSION_ALGORITHM_CONFIG
-    );
-
-    switch (tableCompressionAlgo.name()) {
-      case "SNAPPY" :
-        tableCompressionAlgorithm = SchemaBuilder.snappy();
-        break;
-      case "LZ4" :
-        tableCompressionAlgorithm = SchemaBuilder.lz4();
-        break;
-      case "DEFLATE" :
-        tableCompressionAlgorithm = SchemaBuilder.deflate();
-        break;
-      default :
-        tableCompressionAlgorithm = SchemaBuilder.noCompression();
-    }
+    this.tableCompressionAlgorithm = getString(TABLE_CREATE_COMPRESSION_ALGORITHM_CONFIG);
 
     this.offsetStorageTable = getString(OFFSET_STORAGE_TABLE_CONF);
     this.statementTimeoutMs = getLong(EXECUTE_STATEMENT_TIMEOUT_MS_CONF);
@@ -192,10 +154,6 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
   public static final String SSL_ENABLED_CONFIG = "scylladb.ssl.enabled";
   private static final String SSL_ENABLED_DOC = "Flag to determine if SSL is enabled when connecting to ScyllaDB.";
 
-  public static final String SSL_PROVIDER_CONFIG = "scylladb.ssl.provider";
-  private static final String SSL_PROVIDER_DOC = "The SSL Provider to use when connecting to ScyllaDB. "
-          + "Valid Values are JDK, OPENSSL, OPENSSL_REFCNT.";
-
   public static final String SECURITY_ENABLE_CONFIG = "scylladb.security.enabled";
   static final String SECURITY_ENABLE_DOC = "To enable security while loading "
           + "the sink connector and connecting to ScyllaDB.";
@@ -227,7 +185,7 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
           + "to the number of nodes where data (rows and partitions) are replicated. Data is replicated to multiple (RF=N) nodes";
 
   public static final String COMPRESSION_CONFIG = "scylladb.compression";
-  private static final String COMPRESSION_DOC = "Compression algorithm to use when connecting to ScyllaDB. "
+  private static final String COMPRESSION_DOC = "Compression algorithm to use when communicating with ScyllaDB. "
           + "Valid Values are NONE, SNAPPY, LZ4.";
 
   public static final String TABLE_MANAGE_ENABLED_CONFIG = "scylladb.table.manage.enabled";
@@ -235,7 +193,8 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
 
   public static final String TABLE_CREATE_COMPRESSION_ALGORITHM_CONFIG = "scylladb.table.create.compression.algorithm";
   private static final String TABLE_CREATE_COMPRESSION_ALGORITHM_DOC = "Compression algorithm to use when the table is created. "
-          + "Valid Values are NONE, SNAPPY, LZ4, DEFLATE.";
+      + "Valid Values are NONE, SNAPPY, LZ4, DEFLATE.";
+
 
   public static final String OFFSET_STORAGE_TABLE_CONF = "scylladb.offset.storage.table";
   private static final String OFFSET_STORAGE_TABLE_DOC = "The table within the ScyllaDB keyspace "
@@ -267,12 +226,10 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
   private static final String SSL_CIPHER_SUITES_DOC = "The cipher suites to enable. "
           + "Defaults to none, resulting in a ``minimal quality of service`` according to JDK documentation.";
 
-  public static final String SSL_OPENSLL_KEYCERTCHAIN_CONFIG = "scylladb.ssl.openssl.keyCertChain";
-  private static final String SSL_OPENSLL_KEYCERTCHAIN_DOC = "Path to the SSL certificate file, when using OpenSSL.";
+  private static final String SSL_HOSTNAME_VERIFICATION_CONFIG = "scylladb.ssl.hostname.verification";
 
-  public static final String SSL_OPENSLL_PRIVATEKEY_CONFIG = "ssl.openssl.privateKey";
-  private static final String SSL_OPENSLL_PRIVATEKEY_DOC = "Path to the private key file, when using OpenSSL.";
-
+  private static final String SSL_HOSTNAME_VERIFICATION_DOC = "Whether or not to require validation that the hostname" +
+      " of the server certificate's common name matches the hostname of the server being connected to.";
   public static final String TTL_CONFIG = "scylladb.ttl";
   /*If TTL value is not specified then skip setting ttl value while making insert query*/
   public static final Integer TTL_DEFAULT = null;
@@ -281,7 +238,7 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
           + "If this configuration is not provided, the Sink Connector will perform "
           + "insert operations in ScyllaDB  without TTL setting.";
 
-  private static final String LOAD_BALANCING_LOCAL_DC_CONFIG = "scylladb.loadbalancing.localdc";
+  public static final String LOAD_BALANCING_LOCAL_DC_CONFIG = "scylladb.loadbalancing.localdc";
   private static final String LOAD_BALANCING_LOCAL_DC_DEFAULT = "";
   private static final String LOAD_BALANCING_LOCAL_DC_DOC = "The case-sensitive Data Center name "
           + "local to the machine on which the connector is running. It is a recommended config if "
@@ -378,15 +335,15 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
             .define(
                     COMPRESSION_CONFIG,
                     ConfigDef.Type.STRING,
-                    "NONE",
-                    ConfigDef.ValidString.in(CLIENT_COMPRESSION.keySet().toArray(new String[0])),
+                    "none",
+                    ConfigDef.ValidString.in(CLIENT_COMPRESSION.toArray(new String[0])),
                     ConfigDef.Importance.LOW,
                     COMPRESSION_DOC,
                     CONNECTION_GROUP,
                     5,
                     ConfigDef.Width.SHORT,
                     "Compression",
-                    new ListRecommender(Arrays.asList(CLIENT_COMPRESSION.keySet().toArray())))
+                    new ListRecommender(Arrays.asList(CLIENT_COMPRESSION.toArray())))
             .define(
                     SSL_ENABLED_CONFIG,
                     ConfigDef.Type.BOOLEAN,
@@ -397,19 +354,6 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
                     6,
                     ConfigDef.Width.SHORT,
                     "SSL Enabled?")
-            .define(
-                    SSL_PROVIDER_CONFIG,
-                    ConfigDef.Type.STRING,
-                    SslProvider.JDK.toString(),
-                    ValidEnum.of(SslProvider.class),
-                    ConfigDef.Importance.LOW,
-                    SSL_PROVIDER_DOC,
-                    SSL_GROUP,
-                    0,
-                    ConfigDef.Width.SHORT,
-                    "SSL Provider",
-                    Collections.singletonList(SSL_ENABLED_CONFIG),
-                    new VisibleIfEqual(SSL_ENABLED_CONFIG, true, Arrays.asList(SslProvider.values())))
             .define(
                     SSL_TRUSTSTORE_PATH_CONFIG,
                     ConfigDef.Type.STRING,
@@ -472,42 +416,28 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
                     "The cipher suites to enable",
                     Collections.singletonList(SSL_ENABLED_CONFIG),
                     new VisibleIfEqual(SSL_ENABLED_CONFIG, true))
-            .define(
-                    SSL_OPENSLL_KEYCERTCHAIN_CONFIG,
-                    ConfigDef.Type.STRING,
-                    null,
-                    ConfigDef.Importance.HIGH,
-                    SSL_OPENSLL_KEYCERTCHAIN_DOC,
+            .define(SSL_HOSTNAME_VERIFICATION_CONFIG,
+                    ConfigDef.Type.BOOLEAN,
+                    false,
+                    ConfigDef.Importance.MEDIUM,
+                    SSL_HOSTNAME_VERIFICATION_DOC,
                     SSL_GROUP,
                     6,
                     ConfigDef.Width.SHORT,
-                    "The path to the certificate chain file",
-                    Collections.singletonList(SSL_ENABLED_CONFIG),
-                    new VisibleIfEqual(SSL_ENABLED_CONFIG, true))
-            .define(
-                    SSL_OPENSLL_PRIVATEKEY_CONFIG,
-                    ConfigDef.Type.STRING,
-                    null,
-                    ConfigDef.Importance.HIGH,
-                    SSL_OPENSLL_PRIVATEKEY_DOC,
-                    SSL_GROUP,
-                    7,
-                    ConfigDef.Width.SHORT,
-                    "The path to the private key file",
-                    Collections.singletonList(SSL_ENABLED_CONFIG),
+                    "Hostname verification?",
                     new VisibleIfEqual(SSL_ENABLED_CONFIG, true))
             .define(
                     CONSISTENCY_LEVEL_CONFIG,
                     ConfigDef.Type.STRING,
                     ConsistencyLevel.LOCAL_QUORUM.toString(),
-                    ValidEnum.of(ConsistencyLevel.class),
+                    ValidEnum.of(DefaultConsistencyLevel.class),
                     ConfigDef.Importance.HIGH,
                     CONSISTENCY_LEVEL_DOC,
                     WRITE_GROUP,
                     0,
                     ConfigDef.Width.SHORT,
                     "Consistency Level",
-                    new ListRecommender(Arrays.asList(toStringArray(ConsistencyLevel.values()))))
+                    new ListRecommender(Arrays.asList(DefaultConsistencyLevel.values())))
             .define(
                     DELETES_ENABLE_CONFIG,
                     ConfigDef.Type.BOOLEAN,
@@ -563,8 +493,8 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
             .define(
                     TABLE_CREATE_COMPRESSION_ALGORITHM_CONFIG,
                     ConfigDef.Type.STRING,
-                    "NONE",
-                    ConfigDef.ValidString.in(TABLE_COMPRESSION.keySet().toArray(new String[0])),
+                    "none",
+                    ConfigDef.ValidString.in(TABLE_COMPRESSORS.toArray(new String[0])),
                     ConfigDef.Importance.MEDIUM,
                     TABLE_CREATE_COMPRESSION_ALGORITHM_DOC,
                     TABLE_GROUP,
@@ -572,7 +502,7 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
                     ConfigDef.Width.SHORT,
                     "Table Compression",
                     Collections.singletonList(TABLE_MANAGE_ENABLED_CONFIG),
-                    new VisibleIfEqual(TABLE_MANAGE_ENABLED_CONFIG, true, Arrays.asList(TABLE_COMPRESSION.keySet().toArray(new String[0]))))
+                    new VisibleIfEqual(TABLE_MANAGE_ENABLED_CONFIG, true, Arrays.asList(TABLE_COMPRESSORS.toArray(new String[0]))))
             .define(
                     OFFSET_STORAGE_TABLE_CONF,
                     ConfigDef.Type.STRING,

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkTaskHelper.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkTaskHelper.java
@@ -1,7 +1,7 @@
 package io.connect.scylladb;
 
-import com.datastax.driver.core.BoundStatement;
-import com.google.common.base.Preconditions;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
 import io.connect.scylladb.topictotable.TopicConfigs;
 import io.connect.scylladb.utils.ScyllaDbConstants;
 import org.apache.kafka.common.TopicPartition;
@@ -91,13 +91,13 @@ public class ScyllaDbSinkTaskHelper {
     if (topicConfigs != null) {
       log.trace("Topic mapped Consistency level : " + topicConfigs.getConsistencyLevel()
               + ", Record/Topic mapped timestamp : " + topicConfigs.getTimeStamp());
-      boundStatement.setConsistencyLevel(topicConfigs.getConsistencyLevel());
-      boundStatement.setDefaultTimestamp(topicConfigs.getTimeStamp());
+      boundStatement = boundStatement.setConsistencyLevel(topicConfigs.getConsistencyLevel());
+      boundStatement = boundStatement.setQueryTimestamp(topicConfigs.getTimeStamp());
     } else {
-      boundStatement.setConsistencyLevel(this.scyllaDbSinkConnectorConfig.consistencyLevel);
+      boundStatement = boundStatement.setConsistencyLevel(this.scyllaDbSinkConnectorConfig.consistencyLevel);
       // Timestamps in Kafka (record.timestamp()) are in millisecond precision,
       // while Scylla expects a microsecond precision: 1 ms = 1000 us.
-      boundStatement.setDefaultTimestamp(record.timestamp() * 1000);
+      boundStatement = boundStatement.setQueryTimestamp(record.timestamp() * 1000);
     }
     return boundStatement;
   }

--- a/src/main/java/io/connect/scylladb/TableMetadata.java
+++ b/src/main/java/io/connect/scylladb/TableMetadata.java
@@ -1,6 +1,6 @@
 package io.connect.scylladb;
 
-import com.datastax.driver.core.DataType;
+import com.datastax.oss.driver.api.core.type.DataType;
 
 import java.util.List;
 

--- a/src/main/java/io/connect/scylladb/TableMetadataImpl.java
+++ b/src/main/java/io/connect/scylladb/TableMetadataImpl.java
@@ -1,9 +1,9 @@
 package io.connect.scylladb;
 
-import com.datastax.driver.core.ColumnMetadata;
-import com.datastax.driver.core.DataType;
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
+import com.datastax.oss.driver.api.core.metadata.schema.ColumnMetadata;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.shaded.guava.common.base.MoreObjects;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +21,7 @@ class TableMetadataImpl {
 
     @Override
     public String getName() {
-      return this.columnMetadata.getName();
+      return this.columnMetadata.getName().toString();
     }
 
     @Override
@@ -33,7 +33,7 @@ class TableMetadataImpl {
     public String toString() {
       return MoreObjects.toStringHelper(this)
           .add("name", this.columnMetadata.getName())
-          .add("type", this.columnMetadata.getType().getName())
+          .add("type", this.columnMetadata.getType().asCql(true, true))
           .toString();
     }
   }
@@ -41,21 +41,21 @@ class TableMetadataImpl {
   static class TableImpl implements TableMetadata.Table {
     final String name;
     final String keyspace;
-    final com.datastax.driver.core.TableMetadata tableMetadata;
+    final com.datastax.oss.driver.api.core.metadata.schema.TableMetadata tableMetadata;
     final Map<String, TableMetadata.Column> columns;
     final List<TableMetadata.Column> primaryKey;
 
-    TableImpl(com.datastax.driver.core.TableMetadata tableMetadata) {
+    TableImpl(com.datastax.oss.driver.api.core.metadata.schema.TableMetadata tableMetadata) {
       this.tableMetadata = tableMetadata;
-      this.name = this.tableMetadata.getName();
-      this.keyspace = this.tableMetadata.getKeyspace().getName();
+      this.name = this.tableMetadata.getName().asInternal();
+      this.keyspace = this.tableMetadata.getKeyspace().asInternal();
       this.primaryKey = this.tableMetadata.getPrimaryKey()
           .stream()
           .map(ColumnImpl::new)
           .collect(Collectors.toList());
       List<TableMetadata.Column> allColumns = new ArrayList<>();
       allColumns.addAll(
-          this.tableMetadata.getColumns().stream()
+          this.tableMetadata.getColumns().values().stream()
               .map(ColumnImpl::new)
               .collect(Collectors.toList())
       );

--- a/src/main/java/io/connect/scylladb/codec/ConvenienceCodecs.java
+++ b/src/main/java/io/connect/scylladb/codec/ConvenienceCodecs.java
@@ -1,8 +1,12 @@
 package io.connect.scylladb.codec;
 
-import com.datastax.driver.core.TypeCodec;
-import com.datastax.driver.extras.codecs.MappingCodec;
+import com.datastax.oss.driver.api.core.type.codec.MappingCodec;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodec;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
+import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
@@ -12,258 +16,366 @@ import java.util.Date;
 import java.util.List;
 
 public class ConvenienceCodecs {
-    public static class ByteToBigintCodec extends MappingCodec<Byte, Long> {
+  public static class ByteToBigintCodec extends MappingCodec<Long, Byte> {
 
-        public static final ByteToBigintCodec INSTANCE = new ByteToBigintCodec();
+    public static final ByteToBigintCodec INSTANCE = new ByteToBigintCodec();
 
-        public ByteToBigintCodec() { super(TypeCodec.bigint(), Byte.class); }
+    public ByteToBigintCodec() { super(TypeCodecs.BIGINT, GenericType.BYTE); }
 
-        @Override
-        protected Long serialize(Byte value) { return value.longValue(); }
-
-        @Override
-        protected Byte deserialize(Long value) { return value.byteValue(); }
+    @Nullable
+    @Override
+    protected Byte innerToOuter(@Nullable Long value) {
+      return value == null ? null : value.byteValue();
     }
 
-    public static class ShortToBigintCodec extends MappingCodec<Short, Long> {
+    @Nullable
+    @Override
+    protected Long outerToInner(@Nullable Byte value) {
+      return value == null ? null : value.longValue();
+    }
+  }
 
-        public static final ShortToBigintCodec INSTANCE = new ShortToBigintCodec();
+  public static class ShortToBigintCodec extends MappingCodec<Long, Short> {
 
-        public ShortToBigintCodec() { super(TypeCodec.bigint(), Short.class); }
+    public static final ShortToBigintCodec INSTANCE = new ShortToBigintCodec();
 
-        @Override
-        protected Long serialize(Short value) { return value.longValue(); }
+    public ShortToBigintCodec() { super(TypeCodecs.BIGINT, GenericType.SHORT); }
 
-        @Override
-        protected Short deserialize(Long value) { return value.shortValue(); }
+    @Nullable
+    @Override
+    protected Short innerToOuter(@Nullable Long value) {
+      return value == null ? null : value.shortValue();
     }
 
-    public static class IntegerToBigintCodec extends MappingCodec<Integer, Long> {
+    @Nullable
+    @Override
+    protected Long outerToInner(@Nullable Short value) {
+      return value == null ? null : value.longValue();
+    }
+  }
 
-        public static final IntegerToBigintCodec INSTANCE = new IntegerToBigintCodec();
+  public static class IntegerToBigintCodec extends MappingCodec<Long, Integer> {
 
-        public IntegerToBigintCodec() { super(TypeCodec.bigint(), Integer.class); }
+    public static final IntegerToBigintCodec INSTANCE = new IntegerToBigintCodec();
 
-        @Override
-        protected Long serialize(Integer value) { return value.longValue(); }
+    public IntegerToBigintCodec() { super(TypeCodecs.BIGINT, GenericType.INTEGER); }
 
-        @Override
-        protected Integer deserialize(Long value) { return value.intValue(); }
+    @Nullable
+    @Override
+    protected Integer innerToOuter(@Nullable Long value) {
+      return value == null ? null : value.intValue();
     }
 
-    public static class FloatToDecimalCodec extends MappingCodec<Float, BigDecimal> {
+    @Nullable
+    @Override
+    protected Long outerToInner(@Nullable Integer value) {
+      return value == null ? null : value.longValue();
+    }
+  }
 
-        public static final FloatToDecimalCodec INSTANCE = new FloatToDecimalCodec();
+  public static class FloatToDecimalCodec extends MappingCodec<BigDecimal, Float> {
 
-        public FloatToDecimalCodec() { super(TypeCodec.decimal(), Float.class); }
+    public static final FloatToDecimalCodec INSTANCE = new FloatToDecimalCodec();
 
-        @Override
-        protected BigDecimal serialize(Float value) { return new BigDecimal(value.toString()); }
+    public FloatToDecimalCodec() { super(TypeCodecs.DECIMAL, GenericType.FLOAT); }
 
-        @Override
-        protected Float deserialize(BigDecimal value) { return value.floatValue(); }
+    @Nullable
+    @Override
+    protected Float innerToOuter(@Nullable BigDecimal value) {
+      return value == null ? null : value.floatValue();
     }
 
-    public static class DoubleToDecimalCodec extends MappingCodec<Double, BigDecimal> {
+    @Nullable
+    @Override
+    protected BigDecimal outerToInner(@Nullable Float value) {
+      return value == null ? null : BigDecimal.valueOf(value.doubleValue());
+    }
+  }
 
-        public static final DoubleToDecimalCodec INSTANCE = new DoubleToDecimalCodec();
+  public static class DoubleToDecimalCodec extends MappingCodec<BigDecimal, Double> {
 
-        public DoubleToDecimalCodec() { super(TypeCodec.decimal(), Double.class); }
+    public static final DoubleToDecimalCodec INSTANCE = new DoubleToDecimalCodec();
 
-        @Override
-        protected BigDecimal serialize(Double value) { return new BigDecimal(value.toString()); }
+    public DoubleToDecimalCodec() { super(TypeCodecs.DECIMAL, GenericType.DOUBLE); }
 
-        @Override
-        protected Double deserialize(BigDecimal value) { return value.doubleValue(); }
+    @Nullable
+    @Override
+    protected Double innerToOuter(@Nullable BigDecimal value) {
+      return value == null ? null : value.doubleValue();
     }
 
-    public static class IntegerToDecimalCodec extends MappingCodec<Integer, BigDecimal> {
+    @Nullable
+    @Override
+    protected BigDecimal outerToInner(@Nullable Double value) {
+      return value == null ? null : BigDecimal.valueOf(value);
+    }
+  }
 
-        public static final IntegerToDecimalCodec INSTANCE = new IntegerToDecimalCodec();
+  public static class IntegerToDecimalCodec extends MappingCodec<BigDecimal, Integer> {
 
-        public IntegerToDecimalCodec() { super(TypeCodec.decimal(), Integer.class); }
+    public static final IntegerToDecimalCodec INSTANCE = new IntegerToDecimalCodec();
 
-        @Override
-        protected BigDecimal serialize(Integer value) { return new BigDecimal(value.toString()); }
+    public IntegerToDecimalCodec() { super(TypeCodecs.DECIMAL, GenericType.INTEGER); }
 
-        @Override
-        protected Integer deserialize(BigDecimal value) { return value.intValueExact(); }
+    @Nullable
+    @Override
+    protected Integer innerToOuter(@Nullable BigDecimal value) {
+      return value == null ? null : value.intValue();
     }
 
-    public static class LongToDecimalCodec extends MappingCodec<Long, BigDecimal> {
+    @Nullable
+    @Override
+    protected BigDecimal outerToInner(@Nullable Integer value) {
+      return value == null ? null : BigDecimal.valueOf(value.longValue());
+    }
+  }
 
-        public static final LongToDecimalCodec INSTANCE = new LongToDecimalCodec();
+  public static class LongToDecimalCodec extends MappingCodec<BigDecimal, Long> {
 
-        public LongToDecimalCodec() { super(TypeCodec.decimal(), Long.class); }
+    public static final LongToDecimalCodec INSTANCE = new LongToDecimalCodec();
 
-        @Override
-        protected BigDecimal serialize(Long value) { return new BigDecimal(value.toString()); }
+    public LongToDecimalCodec() { super(TypeCodecs.DECIMAL, GenericType.LONG); }
 
-        @Override
-        protected Long deserialize(BigDecimal value) { return value.longValueExact(); }
+    @Nullable
+    @Override
+    protected Long innerToOuter(@Nullable BigDecimal value) {
+      return value == null ? null : value.longValueExact();
     }
 
-    public static class FloatToDoubleCodec extends MappingCodec<Float, Double> {
+    @Nullable
+    @Override
+    protected BigDecimal outerToInner(@Nullable Long value) {
+      return value == null ? null : BigDecimal.valueOf(value);
+    }
+  }
 
-        public static final FloatToDoubleCodec INSTANCE = new FloatToDoubleCodec();
+  public static class FloatToDoubleCodec extends MappingCodec<Double, Float> {
 
-        public FloatToDoubleCodec() { super(TypeCodec.cdouble(), Float.class); }
+    public static final FloatToDoubleCodec INSTANCE = new FloatToDoubleCodec();
 
-        @Override
-        protected Double serialize(Float value) { return Double.valueOf(value.toString()); }
+    public FloatToDoubleCodec() { super(TypeCodecs.DOUBLE, GenericType.FLOAT); }
 
-        @Override
-        protected Float deserialize(Double value) { return value.floatValue(); }
+    @Nullable
+    @Override
+    protected Float innerToOuter(@Nullable Double value) {
+      return value == null ? null : value.floatValue();
     }
 
-    public static class ByteToIntCodec extends MappingCodec<Byte, Integer> {
+    @Nullable
+    @Override
+    protected Double outerToInner(@Nullable Float value) {
+      return value == null ? null : value.doubleValue();
+    }
+  }
 
-        public static final ByteToIntCodec INSTANCE = new ByteToIntCodec();
+  public static class ByteToIntCodec extends MappingCodec<Integer, Byte> {
 
-        public ByteToIntCodec() { super(TypeCodec.cint(), Byte.class); }
+    public static final ByteToIntCodec INSTANCE = new ByteToIntCodec();
 
-        @Override
-        protected Integer serialize(Byte value) { return Integer.valueOf(value); }
+    public ByteToIntCodec() { super(TypeCodecs.INT, GenericType.BYTE); }
 
-        @Override
-        protected Byte deserialize(Integer value) { return value.byteValue(); }
+    @Nullable
+    @Override
+    protected Byte innerToOuter(@Nullable Integer value) {
+      return value == null ? null : value.byteValue();
     }
 
-    public static class ShortToIntCodec extends MappingCodec<Short, Integer> {
+    @Nullable
+    @Override
+    protected Integer outerToInner(@Nullable Byte value) {
+      return value == null ? null : value.intValue();
+    }
+  }
 
-        public static final ShortToIntCodec INSTANCE = new ShortToIntCodec();
+  public static class ShortToIntCodec extends MappingCodec<Integer, Short> {
 
-        public ShortToIntCodec() { super(TypeCodec.cint(), Short.class); }
+    public static final ShortToIntCodec INSTANCE = new ShortToIntCodec();
 
-        @Override
-        protected Integer serialize(Short value) { return Integer.valueOf(value); }
+    public ShortToIntCodec() { super(TypeCodecs.INT, GenericType.SHORT); }
 
-        @Override
-        protected Short deserialize(Integer value) { return value.shortValue(); }
+    @Nullable
+    @Override
+    protected Short innerToOuter(@Nullable Integer value) {
+      return value == null ? null : value.shortValue();
     }
 
-    public static class LongToIntCodec extends MappingCodec<Long, Integer> {
+    @Nullable
+    @Override
+    protected Integer outerToInner(@Nullable Short value) {
+      return value == null ? null : value.intValue();
+    }
+  }
 
-        public static final LongToIntCodec INSTANCE = new LongToIntCodec();
+  public static class LongToIntCodec extends MappingCodec<Integer, Long> {
 
-        public LongToIntCodec() { super(TypeCodec.cint(), Long.class); }
+    public static final LongToIntCodec INSTANCE = new LongToIntCodec();
 
-        @Override
-        protected Integer serialize(Long value) { return value.intValue(); }
+    public LongToIntCodec() { super(TypeCodecs.INT, GenericType.LONG); }
 
-        @Override
-        protected Long deserialize(Integer value) { return value.longValue(); }
+    @Nullable
+    @Override
+    protected Long innerToOuter(@Nullable Integer value) {
+      return value == null ? null : value.longValue();
     }
 
-    public static class StringToTinyintCodec extends MappingCodec<String, Byte> {
-
-        public static final StringToTinyintCodec INSTANCE = new StringToTinyintCodec();
-
-        public StringToTinyintCodec() { super(TypeCodec.tinyInt(), String.class); }
-
-        @Override
-        protected Byte serialize(String value) { return Byte.parseByte(value); }
-
-        @Override
-        protected String deserialize(Byte value) { return value.toString(); }
+    @Nullable
+    @Override
+    protected Integer outerToInner(@Nullable Long value) {
+      return value == null ? null : value.intValue();
     }
-    
-    public static class StringToSmallintCodec extends MappingCodec<String, Short> {
+  }
 
-        public static final StringToSmallintCodec INSTANCE = new StringToSmallintCodec();
+  public static class StringToTinyintCodec extends MappingCodec<Byte, String> {
 
-        public StringToSmallintCodec() { super(TypeCodec.smallInt(), String.class); }
+    public static final StringToTinyintCodec INSTANCE = new StringToTinyintCodec();
 
-        @Override
-        protected Short serialize(String value) { return Short.parseShort(value); }
+    public StringToTinyintCodec() { super(TypeCodecs.TINYINT, GenericType.STRING); }
 
-        @Override
-        protected String deserialize(Short value) { return value.toString(); }
+    @Nullable
+    @Override
+    protected String innerToOuter(@Nullable Byte value) {
+      return value == null ? null : value.toString();
     }
 
-    public static class StringToIntCodec extends MappingCodec<String, Integer> {
+    @Nullable
+    @Override
+    protected Byte outerToInner(@Nullable String value) {
+      return value == null ? null : Byte.parseByte(value);
+    }
+  }
 
-        public static final StringToIntCodec INSTANCE = new StringToIntCodec();
+  public static class StringToSmallintCodec extends MappingCodec<Short, String> {
 
-        public StringToIntCodec() { super(TypeCodec.cint(), String.class); }
+    public static final StringToSmallintCodec INSTANCE = new StringToSmallintCodec();
 
-        @Override
-        protected Integer serialize(String value) { return Integer.parseInt(value); }
+    public StringToSmallintCodec() { super(TypeCodecs.SMALLINT, GenericType.STRING); }
 
-        @Override
-        protected String deserialize(Integer value) { return value.toString(); }
+    @Nullable
+    @Override
+    protected String innerToOuter(@Nullable Short value) {
+      return value == null ? null : value.toString();
     }
 
-    public static class StringToBigintCodec extends MappingCodec<String, Long> {
+    @Nullable
+    @Override
+    protected Short outerToInner(@Nullable String value) {
+      return value == null ? null : Short.parseShort(value);
+    }
+  }
 
-        public static final StringToBigintCodec INSTANCE = new StringToBigintCodec();
+  public static class StringToIntCodec extends MappingCodec<Integer, String> {
 
-        public StringToBigintCodec() { super(TypeCodec.bigint(), String.class); }
+    public static final StringToIntCodec INSTANCE = new StringToIntCodec();
 
-        @Override
-        protected Long serialize(String value) { return Long.parseLong(value); }
+    public StringToIntCodec() { super(TypeCodecs.INT, GenericType.STRING); }
 
-        @Override
-        protected String deserialize(Long value) { return value.toString(); }
+    @Nullable
+    @Override
+    protected String innerToOuter(@Nullable Integer value) {
+      return value == null ? null : value.toString();
     }
 
-    public static class ByteToSmallintCodec extends MappingCodec<Byte, Short> {
+    @Nullable
+    @Override
+    protected Integer outerToInner(@Nullable String value) {
+      return value == null ? null : Integer.parseInt(value);
+    }
+  }
 
-        public static final ByteToSmallintCodec INSTANCE = new ByteToSmallintCodec();
+  public static class StringToBigintCodec extends MappingCodec<Long, String> {
 
-        public ByteToSmallintCodec() { super(TypeCodec.smallInt(), Byte.class); }
+    public static final StringToBigintCodec INSTANCE = new StringToBigintCodec();
 
-        @Override
-        protected Short serialize(Byte value) { return value.shortValue(); }
+    public StringToBigintCodec() { super(TypeCodecs.BIGINT, GenericType.STRING); }
 
-        @Override
-        protected Byte deserialize(Short value) { return value.byteValue(); }
+    @Nullable
+    @Override
+    protected String innerToOuter(@Nullable Long value) {
+      return value == null ? null : value.toString();
     }
 
-    public static class LongToVarintCodec extends MappingCodec<Long, BigInteger> {
+    @Nullable
+    @Override
+    protected Long outerToInner(@Nullable String value) {
+      return value == null ? null : Long.parseLong(value);
+    }
+  }
 
-        public static final LongToVarintCodec INSTANCE = new LongToVarintCodec();
+  public static class ByteToSmallintCodec extends MappingCodec<Short, Byte> {
 
-        public LongToVarintCodec() { super(TypeCodec.varint(), Long.class); }
+    public static final ByteToSmallintCodec INSTANCE = new ByteToSmallintCodec();
 
-        @Override
-        protected BigInteger serialize(Long value) { return BigInteger.valueOf(value); }
+    public ByteToSmallintCodec() { super(TypeCodecs.SMALLINT, GenericType.BYTE); }
 
-        @Override
-        protected Long deserialize(BigInteger value) { return value.longValueExact(); }
+    @Nullable
+    @Override
+    protected Byte innerToOuter(@Nullable Short value) {
+      return value == null ? null : value.byteValue();
     }
 
-    public static class StringToTimestampCodec extends MappingCodec<String, Date> {
-
-        public static final StringToTimestampCodec INSTANCE = new StringToTimestampCodec();
-
-        public StringToTimestampCodec() { super(TypeCodec.timestamp(), String.class); }
-
-        @Override
-        protected Date serialize(String value) { return Date.from(Instant.parse(value)); }
-
-        @Override
-        protected String deserialize(Date value) { return value.toString(); }
+    @Nullable
+    @Override
+    protected Short outerToInner(@Nullable Byte value) {
+      return value == null ? null : value.shortValue();
     }
-    
-    public static final List<TypeCodec<?>> ALL_INSTANCES = new ArrayList<>(Arrays.asList(
-            ByteToBigintCodec.INSTANCE,
-            ShortToBigintCodec.INSTANCE,
-            IntegerToBigintCodec.INSTANCE,
-            FloatToDecimalCodec.INSTANCE,
-            DoubleToDecimalCodec.INSTANCE,
-            IntegerToDecimalCodec.INSTANCE,
-            LongToDecimalCodec.INSTANCE,
-            FloatToDoubleCodec.INSTANCE,
-            ByteToIntCodec.INSTANCE,
-            ShortToIntCodec.INSTANCE,
-            LongToIntCodec.INSTANCE, //consider removing
-            StringToTinyintCodec.INSTANCE,
-            StringToSmallintCodec.INSTANCE,
-            StringToIntCodec.INSTANCE,
-            StringToBigintCodec.INSTANCE,
-            ByteToSmallintCodec.INSTANCE,
-            LongToVarintCodec.INSTANCE,
-            StringToTimestampCodec.INSTANCE
-    ));
+  }
+
+  public static class LongToVarintCodec extends MappingCodec<BigInteger, Long> {
+
+    public static final LongToVarintCodec INSTANCE = new LongToVarintCodec();
+
+    public LongToVarintCodec() { super(TypeCodecs.VARINT, GenericType.LONG); }
+
+    @Nullable
+    @Override
+    protected Long innerToOuter(@Nullable BigInteger value) {
+      return value == null ? null : value.longValue();
+    }
+
+    @Nullable
+    @Override
+    protected BigInteger outerToInner(@Nullable Long value) {
+      return value == null ? null : BigInteger.valueOf(value);
+    }
+  }
+
+  public static class StringToTimestampCodec extends MappingCodec<Instant, String> {
+
+    public static final StringToTimestampCodec INSTANCE = new StringToTimestampCodec();
+
+    public StringToTimestampCodec() { super(TypeCodecs.TIMESTAMP, GenericType.STRING); }
+
+    @Nullable
+    @Override
+    protected String innerToOuter(@Nullable Instant value) {
+      return value == null ? null : value.toString();
+    }
+
+    @Nullable
+    @Override
+    protected Instant outerToInner(@Nullable String value) {
+      return value == null ? null : Instant.parse(value);
+    }
+  }
+
+  public static final List<TypeCodec<?>> ALL_INSTANCES = new ArrayList<>(Arrays.asList(
+      ByteToBigintCodec.INSTANCE,
+      ShortToBigintCodec.INSTANCE,
+      IntegerToBigintCodec.INSTANCE,
+      FloatToDecimalCodec.INSTANCE,
+      DoubleToDecimalCodec.INSTANCE,
+      IntegerToDecimalCodec.INSTANCE,
+      LongToDecimalCodec.INSTANCE,
+      FloatToDoubleCodec.INSTANCE,
+      ByteToIntCodec.INSTANCE,
+      ShortToIntCodec.INSTANCE,
+      LongToIntCodec.INSTANCE,
+      StringToTinyintCodec.INSTANCE,
+      StringToSmallintCodec.INSTANCE,
+      StringToIntCodec.INSTANCE,
+      StringToBigintCodec.INSTANCE,
+      ByteToSmallintCodec.INSTANCE,
+      LongToVarintCodec.INSTANCE,
+      StringToTimestampCodec.INSTANCE
+  ));
 }

--- a/src/main/java/io/connect/scylladb/codec/StringDurationCodec.java
+++ b/src/main/java/io/connect/scylladb/codec/StringDurationCodec.java
@@ -1,14 +1,13 @@
 package io.connect.scylladb.codec;
 
-import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.Duration;
-import com.datastax.driver.core.TypeCodec;
+import com.datastax.oss.driver.api.core.data.CqlDuration;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 
-public class StringDurationCodec extends StringAbstractCodec<Duration> {
+public class StringDurationCodec extends StringAbstractCodec<CqlDuration> {
+  public static final StringDurationCodec INSTANCE = new StringDurationCodec();
 
-    public static final StringDurationCodec INSTANCE = new StringDurationCodec();
-
-    public StringDurationCodec() {
-        super(DataType.duration(), TypeCodec.duration());
-    }
+  public StringDurationCodec() {
+    super(DataTypes.DURATION, TypeCodecs.DURATION);
+  }
 }

--- a/src/main/java/io/connect/scylladb/codec/StringInetCodec.java
+++ b/src/main/java/io/connect/scylladb/codec/StringInetCodec.java
@@ -1,15 +1,13 @@
 package io.connect.scylladb.codec;
 
-import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.TypeCodec;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
 
 import java.net.InetAddress;
 
 public class StringInetCodec extends StringAbstractCodec<InetAddress> {
-
-    public static final StringInetCodec INSTANCE = new StringInetCodec();
-
-    public StringInetCodec() {
-        super(DataType.inet(), TypeCodec.inet());
-    }
+  public static final StringInetCodec INSTANCE = new StringInetCodec();
+  public StringInetCodec() {
+    super(DataTypes.INET, TypeCodecs.INET);
+  }
 }

--- a/src/main/java/io/connect/scylladb/codec/StringVarintCodec.java
+++ b/src/main/java/io/connect/scylladb/codec/StringVarintCodec.java
@@ -1,13 +1,14 @@
 package io.connect.scylladb.codec;
 
-import com.datastax.driver.core.DataType;
-import com.datastax.driver.core.TypeCodec;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.core.type.codec.TypeCodecs;
+
 import java.math.BigInteger;
 
 public class StringVarintCodec extends StringAbstractCodec<BigInteger> {
-    public static final StringVarintCodec INSTANCE = new StringVarintCodec();
+  public static final  StringVarintCodec INSTANCE = new StringVarintCodec();
 
-    public StringVarintCodec() {
-        super(DataType.varint(), TypeCodec.varint());
-    }
+  public StringVarintCodec() {
+    super(DataTypes.VARINT, TypeCodecs.VARINT);
+  }
 }

--- a/src/main/java/io/connect/scylladb/topictotable/TopicConfigs.java
+++ b/src/main/java/io/connect/scylladb/topictotable/TopicConfigs.java
@@ -1,8 +1,9 @@
 package io.connect.scylladb.topictotable;
 
-import com.datastax.driver.core.ConsistencyLevel;
-import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.DefaultConsistencyLevel;
+import com.datastax.oss.driver.shaded.guava.common.base.Joiner;
+import com.datastax.oss.driver.shaded.guava.common.base.Preconditions;
 import io.connect.scylladb.ScyllaDbSinkConnectorConfig;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -59,7 +60,7 @@ public class TopicConfigs {
         this.ttl = Integer.parseInt(configsMapForTheTopic.get("ttlSeconds"));
       }
       if (configsMapForTheTopic.containsKey("consistencyLevel")) {
-        this.consistencyLevel = ConsistencyLevel.valueOf(configsMapForTheTopic.get("consistencyLevel"));
+        this.consistencyLevel = DefaultConsistencyLevel.valueOf(configsMapForTheTopic.get("consistencyLevel"));
       }
     } catch (NumberFormatException e) {
       throw new DataException(
@@ -68,7 +69,7 @@ public class TopicConfigs {
     } catch (IllegalArgumentException e) {
       throw  new DataException(
               String.format("%s is not a valid value for consistencyLevel. Valid values are %s",
-                      configsMapForTheTopic.get("consistencyLevel"), Arrays.toString(ConsistencyLevel.values()))
+                      configsMapForTheTopic.get("consistencyLevel"), Arrays.toString(DefaultConsistencyLevel.values()))
       );
     }
   }

--- a/src/test/java/io/connect/scylladb/ScyllaDbSinkConnectorConfigTest.java
+++ b/src/test/java/io/connect/scylladb/ScyllaDbSinkConnectorConfigTest.java
@@ -1,6 +1,5 @@
 package io.connect.scylladb;
 
-import org.apache.kafka.common.config.ConfigException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,12 +32,6 @@ public class ScyllaDbSinkConnectorConfigTest {
   public void shouldUseDefaults() {
     config = new ScyllaDbSinkConnectorConfig(settings);
     assertEquals(true, config.keyspaceCreateEnabled);
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void shouldNotAllowInvalidSSLProvide() {
-    settings.put(ScyllaDbSinkConnectorConfig.SSL_PROVIDER_CONFIG, "DKJ");
-    new ScyllaDbSinkConnectorConfig(settings);
   }
 
   //TODO: Add more tests

--- a/src/test/java/io/connect/scylladb/integration/codec/StringTimeUuidCodecTest.java
+++ b/src/test/java/io/connect/scylladb/integration/codec/StringTimeUuidCodecTest.java
@@ -1,7 +1,6 @@
 package io.connect.scylladb.integration.codec;
 
-import com.datastax.driver.core.ProtocolVersion;
-import com.datastax.driver.core.exceptions.InvalidTypeException;
+import com.datastax.oss.driver.api.core.ProtocolVersion;
 import io.connect.scylladb.codec.StringTimeUuidCodec;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -71,21 +70,21 @@ class StringTimeUuidCodecTest {
 
   @Test
   public void shouldFailToSerializeNonType1Strings() {
-    Assertions.assertThrows(InvalidTypeException.class, () -> {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
       assertSerializeAndDeserialize(UUID_STR2);
     });
   }
 
   @Test
   public void shouldFailToSerializeNonUuidString() {
-    Assertions.assertThrows(InvalidTypeException.class, () -> {
-      codec.serialize(NON_UUID_STR, ProtocolVersion.DEFAULT);
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      codec.encode(NON_UUID_STR, ProtocolVersion.V4);
     });
   }
 
   protected void assertSerializeAndDeserialize(String uuidStr) {
-    ByteBuffer buffer = codec.serialize(uuidStr, ProtocolVersion.DEFAULT);
-    String deserialized = codec.deserialize(buffer, ProtocolVersion.DEFAULT);
+    ByteBuffer buffer = codec.encode(uuidStr, ProtocolVersion.V4);
+    String deserialized = codec.decode(buffer, ProtocolVersion.V4);
     assertEquals(uuidStr, deserialized);
   }
 }

--- a/src/test/java/io/connect/scylladb/integration/codec/StringUuidCodecTest.java
+++ b/src/test/java/io/connect/scylladb/integration/codec/StringUuidCodecTest.java
@@ -1,7 +1,6 @@
 package io.connect.scylladb.integration.codec;
 
-import com.datastax.driver.core.ProtocolVersion;
-import com.datastax.driver.core.exceptions.InvalidTypeException;
+import com.datastax.oss.driver.api.core.ProtocolVersion;
 import io.connect.scylladb.codec.StringUuidCodec;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -11,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import java.nio.ByteBuffer;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class StringUuidCodecTest {
@@ -69,14 +67,14 @@ class StringUuidCodecTest {
 
   @Test
   public void shouldFailToSerializeNonUuidString() {
-    Assertions.assertThrows(InvalidTypeException.class, () -> {
-      codec.serialize(NON_UUID_STR, ProtocolVersion.DEFAULT);
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      codec.encode(NON_UUID_STR, ProtocolVersion.V4);
     });
   }
 
   protected void assertSerializeAndDeserialize(String uuidStr) {
-    ByteBuffer buffer = codec.serialize(uuidStr, ProtocolVersion.DEFAULT);
-    String deserialized = codec.deserialize(buffer, ProtocolVersion.DEFAULT);
+    ByteBuffer buffer = codec.encode(uuidStr, ProtocolVersion.V4);
+    String deserialized = codec.decode(buffer, ProtocolVersion.V4);
     assertEquals(uuidStr, deserialized);
   }
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -10,4 +10,4 @@ log4j.logger.org.I0Itec.zkclient=ERROR
 log4j.logger.org.reflections=ERROR
 log4j.logger.org.eclipse.jetty=ERROR
 
-#log4j.logger.io.confluent.connect.scylladb=DEBUG
+#log4j.logger.io.confluent.connect.scylladb=ERROR


### PR DESCRIPTION
Switches driver to newer version trying not to change functionality significantly.

Notable differences:
- Some Java <-> CQL type mappings are different. For example Strings by default will be matched to text instead of varchar.
- OpenSSL configuration options are gone. JDK implementation will be used.