### PR TITLE
Add daily vulnerability scan

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,24 @@
+name: Vulnerability scan
+
+on:
+  schedule:
+  - cron: "44 16 * * *"
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Trivy fs scan
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run trivy in fs mode
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: 'fs'
+        scan-ref: '.'
+        format: 'table'
+        exit-code: '1'
+        ignore-unfixed: false
+        severity: 'CRITICAL,HIGH,MEDIUM'

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
             <!-- should match version from drivers POM -->
-            <version>1.1.10.1</version>
+            <version>1.1.10.4</version>
         </dependency>
 
 


### PR DESCRIPTION
Adds a workflow that will run trivy scanner daily at 16:44 UTC time. Looks for CVEs with at least MEDIUM severity.