### PR TITLE
Fix table compression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
             <!-- should match version from drivers POM -->
-            <version>1.1.10.1</version>
+            <version>1.1.10.5</version>
         </dependency>
 
 

--- a/src/main/java/io/connect/scylladb/ScyllaDbSchemaBuilder.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSchemaBuilder.java
@@ -4,7 +4,6 @@ import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.metadata.schema.SchemaChangeListenerBase;
 import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.api.core.type.DataTypes;
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.*;
 import static com.datastax.oss.driver.api.querybuilder.SchemaBuilder.*;
 
 import com.datastax.oss.driver.api.querybuilder.schema.AlterTableAddColumnEnd;
@@ -21,6 +20,7 @@ import com.datastax.oss.driver.shaded.guava.common.cache.Cache;
 import com.datastax.oss.driver.shaded.guava.common.cache.CacheBuilder;
 
 import com.datastax.oss.driver.shaded.guava.common.collect.ComparisonChain;
+import com.datastax.oss.driver.shaded.guava.common.collect.ImmutableMap;
 import io.connect.scylladb.topictotable.TopicConfigs;
 
 import org.apache.kafka.connect.data.Date;
@@ -220,7 +220,7 @@ class ScyllaDbSchemaBuilder extends SchemaChangeListenerBase {
           alterTableWithOptionsEnd = alterTable.withNoCompression();
         }
         else {
-          alterTableWithOptionsEnd = alterTable.withCompression(config.tableCompressionAlgorithm);
+          alterTableWithOptionsEnd = alterTable.withOption("compression", ImmutableMap.of("sstable_compression", config.tableCompressionAlgorithm));
         }
         String query = alterTableWithOptionsEnd.asCql();
         this.session.executeQuery(query);
@@ -376,7 +376,7 @@ class ScyllaDbSchemaBuilder extends SchemaChangeListenerBase {
         createWithOptions = createWithOptions.withNoCompression();
       }
       else {
-        createWithOptions = createWithOptions.withCompression(config.tableCompressionAlgorithm);
+        createWithOptions = createWithOptions.withOption("compression", ImmutableMap.of("sstable_compression", config.tableCompressionAlgorithm));
       }
       log.info("create() - Adding table {}.{}\n{}", this.config.keyspace, tableName, Arrays.toString(createWithOptions.getOptions().entrySet().toArray()));
       session.executeStatement(createWithOptions.build());

--- a/src/main/java/io/connect/scylladb/ScyllaDbSessionFactory.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSessionFactory.java
@@ -30,7 +30,6 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
-import java.util.Arrays;
 
 public class ScyllaDbSessionFactory {
 


### PR DESCRIPTION
Currently setting table compression fails with
`Missing sub-option 'sstable_compression' for the 'compression' option.`. This is due to Cassandra using now 'class' sub-option and Scylla using 'sstable_compression'. Resolved by calling with customized 'withOption' instead of directly 'withCompression'.

Upgrades snappy to 1.1.10.5. This technically also requires upping the driver version to the one using snappy 1.1.10.5.