### PR TITLE
Bump Snappy version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
             <!-- should match version from drivers POM -->
-            <version>1.1.10.1</version>
+            <version>1.1.10.4</version>
         </dependency>
 
 


### PR DESCRIPTION
Bump Snappy version to 1.1.10.4. The previous version was flagged by security scanners with CVE-2023-43642.