### PR TITLE
Bump java driver version to 4.19.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <failsafe.version>3.0.0-M5</failsafe.version>
         <kafka.version>2.4.0</kafka.version>
         <junit.version>5.2.0</junit.version>
-        <scylladb.version>4.17.0.0</scylladb.version>
+        <scylladb.version>4.19.0.1</scylladb.version>
         <skipIntegrationTests>false</skipIntegrationTests>
         <!-- transitive dependency versions -->
         <jackson-databind.version>2.13.4.2</jackson-databind.version>
@@ -300,6 +300,12 @@
             <version>1.1.10.4</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>3.1.12</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- TODO: Dependency for Integration test -->
         <!--dependency>


### PR DESCRIPTION
Since it changes transitive dependencies spotbugs-annotations dependency was also added.