### PR TITLE
fix: bump kafka-clients to 3.9.2 to remediate CVE-2026-35554

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <kafka.connect.maven.plugin.version>0.12.0</kafka.connect.maven.plugin.version>
         <surefire.version>3.5.4</surefire.version>
         <failsafe.version>3.5.4</failsafe.version>
-        <kafka.version>3.9.1</kafka.version>
+        <kafka.version>3.9.2</kafka.version>
         <junit.version>5.14.3</junit.version>
         <scylladb.version>4.19.0.5</scylladb.version>
         <skipIntegrationTests>false</skipIntegrationTests>


### PR DESCRIPTION
## Summary

Bumps `kafka.version` from `3.9.1` to `3.9.2` to address **CVE-2026-35554** (High severity).

## Vulnerability

**CVE-2026-35554** — Apache Kafka Clients: Kafka Producer Message Corruption and Misrouting via Buffer Pool Race Condition

A race condition in the Kafka Java producer's buffer pool management can cause messages to be silently delivered to incorrect topics.

When a produce batch expires due to `delivery.timeout.ms` while a network request containing that batch is still in-flight, the batch's `ByteBuffer` is prematurely returned to the buffer pool. A subsequent producer batch — potentially destined for a **different topic** — may reuse this freed buffer before the original request completes, corrupting the buffer contents. This results in:

- **Data Confidentiality**: Messages intended for one topic may be delivered to a different topic, potentially exposing sensitive data to unintended consumers.
- **Data Integrity**: Consumers on the receiving topic may encounter unexpected or incompatible messages, leading to deserialization failures and corrupted downstream data.

No error is reported to the producer.

**Affected versions:** `kafka-clients` 2.8.0 – 3.9.1, 4.0.0 – 4.0.1, 4.1.0 – 4.1.1  
**Fixed versions:** 3.9.2, 4.0.2, 4.1.2, 4.2.0  
**References:** [KAFKA-19012](https://issues.apache.org/jira/browse/KAFKA-19012), [Apache Kafka CVE list](https://kafka.apache.org/community/cve-list/)

## Change

Single property bump in `pom.xml`:

```xml
-<kafka.version>3.9.1</kafka.version>
+<kafka.version>3.9.2</kafka.version>
```

This propagates to all five Kafka artifact version references (`connect-api`, `kafka-clients` ×2, `connect-runtime` ×2) via the shared property.