### PR TITLE
fix: override netty to 4.1.133.Final to remediate CVE-2026-42583 (Stage 1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <scylladb.version>4.19.0.5</scylladb.version>
         <skipIntegrationTests>false</skipIntegrationTests>
         <!-- transitive dependency versions -->
+        <netty.version>4.1.133.Final</netty.version>
         <jackson.version>2.21.1</jackson.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <guava.version>33.5.0-jre</guava.version>
@@ -252,6 +253,15 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- CVE-2026-42583: force netty to 4.1.133.Final; remove once scylladb/java-driver
+                 bumps netty.version and a new driver release is consumed here (Stage 3). -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>


### PR DESCRIPTION
## Summary

Closes #164 (Stage 1 of 3)

Confluent Hub security scan flagged connector `1.1.4` for CVE-2026-42583 in `io.netty:netty-codec`. This PR applies an **immediate workaround** by forcing all netty artifacts to `4.1.133.Final` via a `<dependencyManagement>` BOM import.

## Changes

- `pom.xml`: add `<netty.version>4.1.133.Final</netty.version>` property
- `pom.xml`: add `io.netty:netty-bom` BOM import to `<dependencyManagement>`

## Verification

```
$ mvn dependency:tree -Dincludes=io.netty
...
\- com.scylladb:java-driver-core:jar:4.19.0.5:compile
   \- io.netty:netty-handler:jar:4.1.133.Final:compile
      +- io.netty:netty-common:jar:4.1.133.Final:compile
      +- io.netty:netty-resolver:jar:4.1.133.Final:compile
      +- io.netty:netty-buffer:jar:4.1.133.Final:compile
      +- io.netty:netty-transport:jar:4.1.133.Final:compile
      +- io.netty:netty-transport-native-unix-common:jar:4.1.133.Final:compile
      \- io.netty:netty-codec:jar:4.1.133.Final:compile
```

All 7 netty artifacts resolve to `4.1.133.Final`.

## Follow-up

- **Stage 2:** scylladb/java-driver#PR — bump `netty.version` in the driver (root fix)
- **Stage 3:** Once a new driver release is cut, bump `scylladb.version` here and remove the BOM override
