### PR TITLE
fix(cve): bump scylladb driver to 4.19.2.0 — Stage 3 (CVE-2026-42583, CVE-2026-44249, CVE-2026-45416)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,10 +18,9 @@
         <failsafe.version>3.5.6</failsafe.version>
         <kafka.version>3.9.2</kafka.version>
         <junit.version>5.14.4</junit.version>
-        <scylladb.version>4.19.0.9</scylladb.version>
+        <scylladb.version>4.19.2.0</scylladb.version>
         <skipIntegrationTests>false</skipIntegrationTests>
         <!-- transitive dependency versions -->
-        <netty.version>4.1.135.Final</netty.version>
         <jackson.version>2.21.3</jackson.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <guava.version>33.6.0-jre</guava.version>
@@ -248,16 +247,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- CVE-2026-42583, CVE-2026-44249, CVE-2026-45416: force netty to 4.1.135.Final;
-                 remove once scylladb/java-driver bumps netty.version and a new driver
-                 release is consumed here (Stage 3). -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>${netty.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
@@ -373,7 +362,7 @@
             <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
             <!-- should match version from drivers POM -->
-            <version>1.10.1</version>
+            <version>1.11.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary

Bumps `scylladb.version` from `4.19.0.9` to `4.19.2.0`, which inherits the patched netty (`4.1.135.Final`) from the driver, making the temporary BOM override unnecessary.

### CVEs addressed

| CVE | Severity | CVSS | Fixed In | Root Fix PR |
|---|---|---|---|---|
| CVE-2026-42583 | MEDIUM | 6.5 | netty `4.1.133.Final` | scylladb/java-driver#896 |
| CVE-2026-44249 | HIGH | 8.1 | netty `4.1.135.Final` | scylladb/java-driver#925 |
| CVE-2026-45416 | HIGH | 7.5 | netty `4.1.135.Final` | scylladb/java-driver#925 |

### Changes

1. **`scylladb.version`**: `4.19.0.9` → `4.19.2.0` — picks up driver with netty `4.1.135.Final`
2. **Remove `netty.version` property + `netty-bom` import** — no longer needed; the driver itself brings the correct netty version
3. **`lz4-java`**: `1.10.1` → `1.11.0` — aligns with the version declared in the driver POM (`<lz4.version>1.11.0</lz4.version>` on `scylla-4.x`)

### Verification

```bash
mvn dependency:tree -Dincludes=io.netty
# All io.netty artifacts should resolve to 4.1.135.Final

mvn dependency:tree -Dincludes=at.yawk.lz4
# lz4-java should resolve to 1.11.0
```

### Relationship to other PRs

| PR | Stage | Status |
|---|---|---|
| scylladb/java-driver#896 | 2 — root fix (CVE-2026-42583) | Merged |
| scylladb/java-driver#925 | 2 — root fix (CVE-2026-44249, CVE-2026-45416) | Merged |
| #165 | 1 — temporary netty-bom override (CVE-2026-42583) | Superseded by #185 |
| #185 | 1 — temporary netty-bom override (CVE-2026-44249, CVE-2026-45416) | Merged |
| **This PR** | 3 — consume fixed driver release | Ready |

Once this PR merges:
- The netty overrides from #185 are removed (included in this diff)
- Renovate PR #156 (`lz4-java 1.10.1 → 1.11.0`) can be closed — superseded by this PR
- Renovate PR #171 (`netty 4.1.x → 4.2.x`) should be closed — incompatible version line

Closes #164, closes #184