### PR TITLE
chore(deps): update maven-surefire-plugin to 3.5.5 and remove duplicate declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.5</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <version>3.2.8</version>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.inceptionYear>2020</project.inceptionYear>
         <license.current.year>2026</license.current.year>
         <kafka.connect.maven.plugin.version>0.12.0</kafka.connect.maven.plugin.version>
-        <surefire.version>3.5.4</surefire.version>
+        <surefire.version>3.5.5</surefire.version>
         <failsafe.version>3.5.4</failsafe.version>
         <kafka.version>3.9.2</kafka.version>
         <junit.version>5.14.3</junit.version>
@@ -34,7 +34,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.4</version>
+                <version>3.5.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Two commits:

1. **Bump `<surefire.version>` 3.5.4 → 3.5.5** — the property controlling the configured surefire execution (`<excludedGroups>`, `<trimStackTrace>`).
2. **Remove duplicate surefire plugin declaration** — there were two `maven-surefire-plugin` entries in the same `<build><plugins>` block. The first (lines 34–38) had only a hardcoded version with no configuration. The second (lines 132–140) had `${surefire.version}` and the actual configuration. Maven merges duplicate plugin declarations and the first version wins, meaning `${surefire.version}` was silently ignored. Removing the redundant first declaration makes `<surefire.version>` the single source of truth.

**Testing:** 25 unit tests pass (`mvn test -DskipIntegrationTests=true` with Java 11).

Closes #154
Closes #155