### PR TITLE
chore(deps): update maven-failsafe-plugin to 3.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <license.current.year>2026</license.current.year>
         <kafka.connect.maven.plugin.version>0.12.0</kafka.connect.maven.plugin.version>
         <surefire.version>3.5.5</surefire.version>
-        <failsafe.version>3.5.4</failsafe.version>
+        <failsafe.version>3.5.5</failsafe.version>
         <kafka.version>3.9.2</kafka.version>
         <junit.version>5.14.3</junit.version>
         <scylladb.version>4.19.0.5</scylladb.version>


### PR DESCRIPTION
Bumps `<failsafe.version>` from `3.5.4` to `3.5.5`. Supersedes Renovate PR #153.

**Testing:** 25 unit tests pass (`mvn test -DskipIntegrationTests=true` with Java 11).

Closes #153