### PR TITLE
chore(deps): update junit-jupiter-api to 5.14.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <surefire.version>3.5.5</surefire.version>
         <failsafe.version>3.5.5</failsafe.version>
         <kafka.version>3.9.2</kafka.version>
-        <junit.version>5.14.3</junit.version>
+        <junit.version>5.14.4</junit.version>
         <scylladb.version>4.19.0.5</scylladb.version>
         <skipIntegrationTests>false</skipIntegrationTests>
         <!-- transitive dependency versions -->


### PR DESCRIPTION
Bumps `<junit.version>` from `5.14.3` to `5.14.4`. Supersedes Renovate PR #166 (which was based on a stale branch and would have regressed surefire/failsafe and netty changes).

**Testing:** 25 unit tests pass (`mvn test -DskipIntegrationTests=true` with Java 11).

Closes #166