### PR TITLE
ci: publish JAR and ZIP artifacts on GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,3 +106,16 @@ jobs:
         run: |
           git status && git log -3
           git push origin --follow-tags -v
+
+      - name: Create GitHub Release
+        if: inputs.dry-run == false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_TAG=$(git describe --tags --abbrev=0)
+          VERSION=${RELEASE_TAG#v}
+          gh release create "${RELEASE_TAG}" \
+            "target/checkout/target/kafka-connect-scylladb-${VERSION}.jar" \
+            "target/checkout/target/components/packages/scylladb-kafka-connect-scylladb-${VERSION}.zip" \
+            --title "${VERSION}" \
+            --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,14 +108,18 @@ jobs:
           git push origin --follow-tags -v
 
       - name: Create GitHub Release
-        if: inputs.dry-run == false
+        if: inputs.dry-run == false && inputs.target-tag == 'master'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RELEASE_TAG=$(git describe --tags --abbrev=0)
           VERSION=${RELEASE_TAG#v}
-          gh release create "${RELEASE_TAG}" \
-            "target/checkout/target/kafka-connect-scylladb-${VERSION}.jar" \
-            "target/checkout/target/components/packages/scylladb-kafka-connect-scylladb-${VERSION}.zip" \
-            --title "${VERSION}" \
-            --generate-notes
+          JAR="target/checkout/target/kafka-connect-scylladb-${VERSION}.jar"
+          ZIP="target/checkout/target/components/packages/scylladb-kafka-connect-scylladb-${VERSION}.zip"
+          if gh release view "${RELEASE_TAG}" &>/dev/null; then
+            gh release upload "${RELEASE_TAG}" "${JAR}" "${ZIP}" --clobber
+          else
+            gh release create "${RELEASE_TAG}" "${JAR}" "${ZIP}" \
+              --title "${VERSION}" \
+              --generate-notes
+          fi


### PR DESCRIPTION
## Summary

Adds a **Create GitHub Release** step to the release workflow, mirroring what `scylla-cdc-source-connector` already does.

After a successful `mvn release:perform` and SCM push, the workflow now automatically:
1. Creates a GitHub Release tagged with the released version
2. Attaches the connector JAR and Confluent Hub ZIP as downloadable assets
3. Auto-generates release notes from merged PRs (`--generate-notes`)

The step is skipped when `dry-run: true`, consistent with the existing SCM push behaviour.

## Changed files

- `.github/workflows/release.yml` — appended the new step (14 lines)

## Artifacts attached per release

| File | Description |
|---|---|
| `kafka-connect-scylladb-{VERSION}.jar` | Connector JAR |
| `scylladb-kafka-connect-scylladb-{VERSION}.zip` | Confluent Hub installable ZIP |
