### PR TITLE
ci: automate email notification to Confluent Hub on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
 
     permissions:
       contents: write
+      issues: write
 
     env:
       MVNCMD: mvn -B -X -ntp
@@ -123,3 +124,84 @@ jobs:
               --title "${VERSION}" \
               --generate-notes
           fi
+
+      # Every step below is continue-on-error: a bounced email must not turn a
+      # published release red, because a red release invites a re-run, and
+      # re-running this single-job workflow calls mvn release:prepare again and
+      # cuts a spurious version.
+      - name: Extract release version
+        id: extract-version
+        if: inputs.dry-run == false && inputs.target-tag == 'master'
+        continue-on-error: true
+        run: |
+          # tagNameFormat is @{project.version}, so the tag *is* the version — no v prefix.
+          RELEASE_VERSION=$(git describe --tags --abbrev=0)
+          # Exported before validation so the fallback issue can quote what was found.
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "$GITHUB_ENV"
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::warning::unexpected release tag '${RELEASE_VERSION}'; skipping the Confluent email"
+            exit 1
+          fi
+
+      - name: Notify Confluent Hub
+        id: notify-confluent
+        if: inputs.dry-run == false && inputs.target-tag == 'master' && steps.extract-version.outcome == 'success'
+        continue-on-error: true
+        uses: dawidd6/action-send-mail@2cea9617b09d79a095af21254fbcb7ae95903dde # v3.12.0
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          secure: true
+          username: ${{ secrets.EMAIL_USERNAME }}
+          password: ${{ secrets.EMAIL_PASSWORD }}
+          from: drivers-team-bot@scylladb.com
+          to: confluent-hub@confluent.io
+          cc: drivers-team@scylladb.com
+          subject: "Publish kafka-connect-scylladb ${{ env.RELEASE_VERSION }}"
+          body: |
+            Dear CCET Team,
+
+            Please publish version ${{ env.RELEASE_VERSION }} of kafka-connect-scylladb:
+            https://github.com/scylladb/kafka-connect-scylladb/releases/download/${{ env.RELEASE_VERSION }}/scylladb-kafka-connect-scylladb-${{ env.RELEASE_VERSION }}.zip
+
+            Best regards,
+            Drivers Team at ScyllaDB
+
+      - name: Open fallback issue if Confluent was not notified
+        if: inputs.dry-run == false && inputs.target-tag == 'master' && (steps.extract-version.outcome == 'failure' || steps.notify-confluent.outcome == 'failure')
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BODY=$(cat <<EOF
+          The automated notification to Confluent failed during the release of
+          \`${RELEASE_VERSION:-unknown tag}\`
+          ([run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})).
+          The release itself succeeded — only the email did not go out.
+
+          **Do not re-run the Release workflow.** It would call \`mvn release:prepare\`
+          again and cut an extra version. Send the message below by hand, then close
+          this issue.
+
+          To: confluent-hub@confluent.io
+          CC: drivers-team@scylladb.com
+          Subject: Publish kafka-connect-scylladb ${RELEASE_VERSION}
+
+          Dear CCET Team,
+
+          Please publish version ${RELEASE_VERSION} of kafka-connect-scylladb:
+          https://github.com/scylladb/kafka-connect-scylladb/releases/download/${RELEASE_VERSION}/scylladb-kafka-connect-scylladb-${RELEASE_VERSION}.zip
+
+          Best regards,
+          Drivers Team at ScyllaDB
+          EOF
+          )
+          # Annotate and record before creating the issue: the summary write cannot
+          # fail, so the message survives even when the issue API does not.
+          echo "::warning::Confluent Hub was not notified automatically; see the run summary."
+          printf '%s\n' "$BODY" >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+          gh issue create \
+            --repo "${GITHUB_REPOSITORY}" \
+            --assignee "${GITHUB_ACTOR}" \
+            --title "Manual action: notify Confluent Hub about ${RELEASE_VERSION:-the latest release}" \
+            --body "$BODY"


### PR DESCRIPTION
## Summary

Closes #112

After every release someone had to email `confluent-hub@confluent.io` by hand so the new version
appears on Confluent Hub. The release workflow now sends it. This is the same change as
[scylla-cdc-source-connector#268](https://github.com/scylladb/scylla-cdc-source-connector/pull/268),
whose SMTP config is already proven by a passing
[run](https://github.com/scylladb/scylla-cdc-source-connector/actions/runs/32727655542).

Tracked as DRIVER-967.

## The change

Three steps, added after `Create GitHub Release`:

| Step | Purpose |
|---|---|
| `Extract release version` | Reads the tag `mvn release:prepare` created and exports `RELEASE_VERSION`, refusing anything that is not `X.Y.Z`. |
| `Notify Confluent Hub` | Sends the publish request over Gmail SMTP as `drivers-team-bot@scylladb.com`. |
| `Open fallback issue…` | Turns any failure above into an assigned GitHub issue holding the ready-to-send message. |

All three carry `if: inputs.dry-run == false && inputs.target-tag == 'master'`, matching the
surrounding steps. The `target-tag` guard is what stops a re-release of an existing tag from
notifying Confluent a second time.

The job also gains `issues: write`, which the fallback step needs.

### Not a copy-paste from the sibling repo

`tagNameFormat` here is `@{project.version}`, so tags carry **no `v` prefix** (`1.1.8`, not
`v1.1.8`) and the tag and the version are the same string. So this uses a single `RELEASE_VERSION`
instead of the `RELEASE_TAG`/`RELEASE_VERSION` pair, and the regex has no `v`. Carrying the
cdc-source-connector version over unchanged would have produced a `…/download/v1.1.8/…` link that
404s.

### Failure behaviour

Every step here is `continue-on-error`, so a bounced email never turns a successful release red.
That matters because this is a single-job workflow: a red release invites a *Re-run*, which would
call `mvn release:prepare` again and cut a spurious extra version. Instead the job stays green and
the notification becomes a GitHub issue assigned to whoever dispatched the release — and that issue
says explicitly not to re-run. The annotation and the run-summary record are written *before*
`gh issue create`, so the message survives even if the issue API is the thing that failed.

### Email that will be sent

```
From: drivers-team-bot@scylladb.com
To: confluent-hub@confluent.io
CC: drivers-team@scylladb.com
Subject: Publish kafka-connect-scylladb 1.1.9

Dear CCET Team,

Please publish version 1.1.9 of kafka-connect-scylladb:
https://github.com/scylladb/kafka-connect-scylladb/releases/download/1.1.9/scylladb-kafka-connect-scylladb-1.1.9.zip
```

The ZIP is linked rather than attached: the 1.1.8 package is 19.4 MB, ~25.8 MB base64-encoded, over
Gmail's 25 MB message limit — an attachment would bounce, and would only grow each release.

## Testing

`release.yml` runs only on `workflow_dispatch` at release time and every new step is gated on
`dry-run == false`, so a dry run skips all of them. Verified instead:

- Both `run:` blocks executed locally across six scenarios — valid tag, malformed tag, a `v`-prefixed
  tag (correctly rejected), the fallback rendering, the fallback with `gh` forced to fail, and the
  fallback with the version unset. The tag value is exported *before* validation, so the fallback
  issue quotes what was actually found instead of rendering a blank subject.
- `actionlint` clean, which shellchecks the `run:` blocks.
- The download URL template returns HTTP 200 against the real 1.1.8 asset.
- The rendered email itself sent to a real inbox from a throwaway branch, to confirm wording and
  formatting before it can ever reach Confluent.
