### PR TITLE
fix: override netty to 4.1.135.Final to remediate CVE-2026-44249 and CVE-2026-45416 (Stage 1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <scylladb.version>4.19.0.9</scylladb.version>
         <skipIntegrationTests>false</skipIntegrationTests>
         <!-- transitive dependency versions -->
-        <netty.version>4.1.133.Final</netty.version>
+        <netty.version>4.1.135.Final</netty.version>
         <jackson.version>2.21.3</jackson.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <guava.version>33.5.0-jre</guava.version>
@@ -248,8 +248,9 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- CVE-2026-42583: force netty to 4.1.133.Final; remove once scylladb/java-driver
-                 bumps netty.version and a new driver release is consumed here (Stage 3). -->
+            <!-- CVE-2026-42583, CVE-2026-44249, CVE-2026-45416: force netty to 4.1.135.Final;
+                 remove once scylladb/java-driver bumps netty.version and a new driver
+                 release is consumed here (Stage 3). -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>


### PR DESCRIPTION
## Summary

Closes #184 (Stage 1 of 3)

Confluent Hub security scan flagged connector `1.1.5` for CVE-2026-44249 and CVE-2026-45416 in `io.netty:netty-handler`. This PR applies an **immediate workaround** by bumping the existing `<netty.version>` property from `4.1.133.Final` to `4.1.135.Final`.

## Vulnerabilities

| CVE | Severity | CVSS | Description |
|---|---|---|---|
| CVE-2026-44249 | HIGH | 8.1 | IPv6 subnet rule bypass via incorrect masking in `IpSubnetFilterRule.compareTo()` |
| CVE-2026-45416 | HIGH | 7.5 | Unbounded 16 MiB memory allocation in `SslClientHelloHandler.decode()` (DoS) |

## Changes

- `pom.xml`: bump `<netty.version>` from `4.1.133.Final` to `4.1.135.Final`
- `pom.xml`: update `<dependencyManagement>` comment to reference new CVEs

## Verification

```
$ mvn dependency:tree -Dincludes=io.netty
...
\- com.scylladb:java-driver-core:jar:4.19.0.9:compile
   \- io.netty:netty-handler:jar:4.1.135.Final:compile
      +- io.netty:netty-common:jar:4.1.135.Final:compile
      +- io.netty:netty-resolver:jar:4.1.135.Final:compile
      +- io.netty:netty-buffer:jar:4.1.135.Final:compile
      +- io.netty:netty-transport:jar:4.1.135.Final:compile
      +- io.netty:netty-transport-native-unix-common:jar:4.1.135.Final:compile
      \- io.netty:netty-codec:jar:4.1.135.Final:compile
```

All 7 netty artifacts resolve to `4.1.135.Final`.

## Follow-up

- **Stage 2:** scylladb/java-driver — bump `netty.version` in the driver (root fix)
- **Stage 3:** Once a new driver release is cut, bump `scylladb.version` here and remove the BOM override
