### PR TITLE
fix: use NetworkTopologyStrategy for keyspace creation to support ScyllaDB 2026.x

### DIFF
--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkConnector.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkConnector.java
@@ -53,7 +53,7 @@ public class ScyllaDbSinkConnector extends SinkConnector {
         CreateKeyspace createKeyspace = SchemaBuilder.createKeyspace(config.keyspace)
                 .ifNotExists()
                 .withReplicationOptions(ImmutableMap.of(
-                "class", (Object) "SimpleStrategy",
+                "class", (Object) "NetworkTopologyStrategy",
                 "replication_factor", config.keyspaceReplicationFactor
                   ))
             .withDurableWrites(true);


### PR DESCRIPTION
Fixes #191.

## Problem

`ScyllaDbSinkConnector.java` hardcodes `SimpleStrategy` when creating the connector keyspace. ScyllaDB 2025.4+ enables tablets by default for all user keyspaces, and tablets require `NetworkTopologyStrategy` — `SimpleStrategy` is outright rejected with:

```
InvalidConfigurationInQueryException: SimpleStrategy doesn't support tablet replication
```

This causes the connector to fail at startup whenever `scylladb.keyspace.create.enabled=true` is used against ScyllaDB 2025.4+. It is also the root cause of the CI failures in PR #167.

## Fix

One-line change: replace `"SimpleStrategy"` with `"NetworkTopologyStrategy"` in the `withReplicationOptions` call.

`NetworkTopologyStrategy` accepts `replication_factor` as a shorthand ([ScyllaDB docs](https://opensource.docs.scylladb.com/stable/cql/ddl.html#create-keyspace)) that auto-expands to all datacenters in the cluster. No DC name is required — the existing `config.keyspaceReplicationFactor` continues to be honoured as-is.

## Backwards Compatibility

- The `IF NOT EXISTS` clause means existing keyspaces are not affected.
- `NetworkTopologyStrategy` with the `replication_factor` shorthand is supported by ScyllaDB (all versions) and Cassandra 4.0+.
- The connector's tables have no counters, secondary indexes, or materialized views, so they are fully tablet-compatible without any `tablets = {'enabled': false}` workaround.