### PR TITLE
fix(cve): bump jackson-databind to 2.21.4 to remediate 6 CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <scylladb.version>4.19.2.0</scylladb.version>
         <skipIntegrationTests>false</skipIntegrationTests>
         <!-- transitive dependency versions -->
-        <jackson.version>2.21.3</jackson.version>
+        <jackson.version>2.21.4</jackson.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <guava.version>33.6.0-jre</guava.version>
         <gpg.passphrase />


### PR DESCRIPTION
Fixes #193.

## Problem

A Confluent Hub security scan of v1.1.6 flagged 7 CVEs in `jackson-databind-2.21.3.jar`, two of which are HIGH severity (CVSS 8.1):

| CVE | Severity | CVSS |
|---|---|---|
| CVE-2026-54512 | HIGH | 8.1 |
| CVE-2026-54513 | HIGH | 8.1 |
| CVE-2026-54514 | MEDIUM | 5.3 |
| CVE-2026-54515 | MEDIUM | 5.3 |
| CVE-2026-54516 | MEDIUM | 5.3 |
| CVE-2026-54517 | MEDIUM | 5.3 |
| CVE-2026-54518 | MEDIUM | 6.5 |

## Fix

Bump `jackson.version` from `2.21.3` → `2.21.4` in `pom.xml`.

This resolves 6 of 7 CVEs (both HIGHs + CVE-2026-54514, 54516, 54517, 54518). CVE-2026-54515 requires `2.21.5` which is not yet available on Maven Central and is tracked separately.

## Notes

- No conflict with PR #167 (driver bump) or PR #192 (NTS keyspace fix) — this touches a different line in `pom.xml`.
- This PR targets `master`; it will be included in the v1.1.7 release along with #167 and #192.