### PR TITLE
fix(cve): bump jackson to 2.21.5 to remediate CVE-2026-54515

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <scylladb.version>4.19.2.0</scylladb.version>
         <skipIntegrationTests>false</skipIntegrationTests>
         <!-- transitive dependency versions -->
-        <jackson.version>2.21.4</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <guava.version>33.6.0-jre</guava.version>
         <gpg.passphrase />


### PR DESCRIPTION
## Summary

Bumps `jackson.version` from 2.21.4 to 2.21.5.

This remediates **CVE-2026-54515** (jackson-databind), which was previously deferred because the fix required jackson 2.21.5 and that version was not yet available on Maven Central.

## Changes

- `pom.xml`: `jackson.version` 2.21.4 → 2.21.5 (`jackson-core` and `jackson-databind` both pinned via this property)

## CVEs addressed

| CVE | Component | Fixed in |
|---|---|---|
| CVE-2026-54515 | jackson-databind | 2.21.5 |

CVE-2026-54512 through CVE-2026-54514 and CVE-2026-54516 through CVE-2026-54518 were already addressed in PR #194 (jackson 2.21.4).