### PR TITLE
Add expiration-based dynamic TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ This connector provides support for TTL by which data can be automatically expir
 ``TTL`` value is the time to live value for the data. After that particular amount of time, data will be automatically deleted. For example, if the TTL value is set to 100 seconds then data would be automatically deleted after 100 seconds.
 To use this feature you have to set ``scylladb.ttl`` config with time(in seconds) for which you want to retain the data. If you don't specify this property then the record will be inserted with default TTL value null, meaning that written data will not expire.
 
+TTL can also be selected per record through a topic mapping. Use ``__ttl=value.field`` when the field contains a
+relative lifetime in seconds. Use ``__expiration=value.field`` when the field contains an absolute Kafka
+``Timestamp`` or Unix epoch timestamp in milliseconds. An optional
+``topic.<topic>.<keyspace>.<table>.expirationOffsetSeconds`` value is added to the absolute timestamp before the TTL
+is calculated. For example, an offset of ``86400`` expires a record one day after its expiration field.
+
 --------------------------------
 Offset tracking Support in Kafka
 --------------------------------

--- a/documentation/CONFIG.md
+++ b/documentation/CONFIG.md
@@ -189,13 +189,18 @@ Also, these topic level configurations will override the behavior of Connector l
   For example if you're using RegexRouter to change the topic name from `top1` to `top2` you would use `topic.top2.ks.table.mapping=...` property.
   
   **Note**: Ensure that the data type of the Kafka record's fields are compatible with the data type of the ScyllaDB column.
-  In the Kafka topic mapping, you can optionally specify which column should be used as the ttl (time-to-live) and 
-  timestamp of the record being inserted into the database table using the special property __ttl and __timestamp.
+  In the Kafka topic mapping, you can optionally specify fields that control the ttl (time-to-live), absolute
+  expiration time, and write timestamp of the record using the special properties ``__ttl``, ``__expiration``,
+  and ``__timestamp``.
+  ``__ttl`` must reference an Integer field containing a relative lifetime in seconds.
+  ``__expiration`` must reference a Kafka Timestamp or a Long containing a Unix epoch timestamp in milliseconds.
+  The connector calculates a per-record TTL from the absolute expiration time.
+  A mapping cannot contain both ``__ttl`` and ``__expiration``.
   By default, the database internally tracks the write time(timestamp) of records inserted into Kafka. 
   However, this __timestamp feature in the mapping supports the scenario where the Kafka records have an explicit 
   timestamp field that you want to use as a write time for the database record produced by the connector. 
   Eg. "topic.my_topic.my_ks.my_table.mapping": 
-  "column1=key.field1, column2=value.field1, __ttl=value.field2, __timestamp=value.field3, column3=header.field1"
+  "column1=key.field1, column2=value.field1, __expiration=value.validUntil, __timestamp=value.field3, column3=header.field1"
   
 ``topic.my_topic.my_ks.my_table.consistencyLevel``
 
@@ -204,6 +209,13 @@ Also, these topic level configurations will override the behavior of Connector l
 ``topic.my_topic.my_ks.my_table.ttlSeconds``
 
   By using this property we can specify table wide ttl(time-to-live).
+
+``topic.my_topic.my_ks.my_table.expirationOffsetSeconds``
+
+  A non-negative number of seconds added to the timestamp referenced by ``__expiration`` before calculating TTL.
+  For example, use ``86400`` to expire a record one day after its expiration timestamp. The default is ``0``.
+  If the resulting expiration time is not in the future, record processing follows the configured
+  ``behavior.on.error`` policy.
 
 ``topic.my_topic.my_ks.my_table.deletesEnabled``
 

--- a/documentation/EXAMPLES.md
+++ b/documentation/EXAMPLES.md
@@ -2,6 +2,26 @@
 Below are examples of non-trivial connector configurations.   
 For simpler step-by-step instructions with environment setup check out [quickstart](QUICKSTART.md) first.
 
+## Expire records after a validity date
+
+The following mapping uses the ``validUntil`` field as an absolute expiration timestamp and keeps each record for one
+additional day. ``validUntil`` can be a Kafka Timestamp or a Long Unix epoch timestamp in milliseconds.
+
+```
+topics = events
+scylladb.keyspace = example_ks
+topic.events.example_ks.events.mapping = id=key.id, payload=value.payload, __expiration=value.validUntil
+topic.events.example_ks.events.expirationOffsetSeconds = 86400
+```
+
+At insert time the connector calculates:
+
+```
+TTL = ceil((validUntil + 86400 seconds - current time) / 1 second)
+```
+
+Records whose resulting expiration time is not in the future are handled according to ``behavior.on.error``.
+
 
 ## One topic to many tables
 

--- a/src/main/java/io/connect/scylladb/ScyllaDbSessionImpl.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSessionImpl.java
@@ -162,7 +162,7 @@ class ScyllaDbSessionImpl implements ScyllaDbSession {
     log.debug("insert() - Preparing statement. '{}'", regularInsert.asCql());
     if (topicConfigs != null) {
       return (topicConfigs.getTtl() == null) ? session.prepare(regularInsert.build()) :
-              session.prepare(regularInsert.usingTtl(topicConfigs.getTtl()).build());
+              session.prepare(regularInsert.usingTtl(QueryBuilder.bindMarker("__ttl")).build());
     } else {
       return (config.ttl == null) ? session.prepare(regularInsert.build()) :
               session.prepare(regularInsert.usingTtl(config.ttl).build());
@@ -171,11 +171,7 @@ class ScyllaDbSessionImpl implements ScyllaDbSession {
 
   @Override
   public RecordToBoundStatementConverter insert(String tableName, TopicConfigs topicConfigs) {
-    if (topicConfigs != null && topicConfigs.getTtl() != null) {
-      PreparedStatement preparedStatement = createInsertPreparedStatement(tableName, topicConfigs);
-      return new RecordToBoundStatementConverter(preparedStatement);
-    } else {
-      return this.insertStatementCache.computeIfAbsent(
+    return this.insertStatementCache.computeIfAbsent(
               tableName,
               new Function<String, RecordToBoundStatementConverter>() {
                 @Override
@@ -185,7 +181,6 @@ class ScyllaDbSessionImpl implements ScyllaDbSession {
                 }
               }
       );
-    }
   }
 
   private PreparedStatement offsetPreparedStatement;

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkConnectorConfig.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkConnectorConfig.java
@@ -62,9 +62,11 @@ public class ScyllaDbSinkConnectorConfig extends AbstractConfig {
   public final List<String> cipherSuites;
 
   private static final Pattern TOPIC_KS_TABLE_SETTING_PATTERN =
-          Pattern.compile("topic\\.([a-zA-Z0-9._-]+)\\.([^.]+|\"[\"]+\")\\.([^.]+|\"[\"]+\")\\.(mapping|consistencyLevel|ttlSeconds|deletesEnabled)$");
+          Pattern.compile("topic\\.([a-zA-Z0-9._-]+)\\.([^.]+|\"[\"]+\")\\.([^.]+|\"[\"]+\")\\.(mapping|consistencyLevel|ttlSeconds|expirationOffsetSeconds|deletesEnabled)$");
 
-  private static final String[] TOPIC_WISE_CONFIGS_VALID_SUFFIXES = {".mapping",".consistencyLevel",".ttlSeconds",".deletesEnabled"};
+  private static final String[] TOPIC_WISE_CONFIGS_VALID_SUFFIXES = {
+          ".mapping", ".consistencyLevel", ".ttlSeconds", ".expirationOffsetSeconds", ".deletesEnabled"
+  };
 
   private static final Logger log = LoggerFactory.getLogger(ScyllaDbSinkConnectorConfig.class);
 

--- a/src/main/java/io/connect/scylladb/ScyllaDbSinkTaskHelper.java
+++ b/src/main/java/io/connect/scylladb/ScyllaDbSinkTaskHelper.java
@@ -86,6 +86,9 @@ public class ScyllaDbSinkTaskHelper {
       final RecordToBoundStatementConverter boundStatementConverter = this.session.insert(tableName, topicConfigs);
       final RecordToBoundStatementConverter.State state = boundStatementConverter.convert(record, topicConfigs, ScyllaDbConstants.INSERT_OPERATION);
       boundStatement = state.statement;
+      if (topicConfigs != null && topicConfigs.getTtl() != null) {
+        boundStatement = boundStatement.setInt("__ttl", topicConfigs.getTtl());
+      }
     }
 
     if (topicConfigs != null) {

--- a/src/main/java/io/connect/scylladb/topictotable/TopicConfigs.java
+++ b/src/main/java/io/connect/scylladb/topictotable/TopicConfigs.java
@@ -15,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -28,6 +29,8 @@ public class TopicConfigs {
   private ConsistencyLevel consistencyLevel = null;
   private String ttlMappedField;
   private Integer ttl;
+  private String expirationMappedField;
+  private int expirationOffsetSeconds;
   private String timeStampMappedField;
   private Long timeStamp;
   private boolean deletesEnabled;
@@ -59,13 +62,18 @@ public class TopicConfigs {
       if (configsMapForTheTopic.containsKey("ttlSeconds")) {
         this.ttl = Integer.parseInt(configsMapForTheTopic.get("ttlSeconds"));
       }
+      if (configsMapForTheTopic.containsKey("expirationOffsetSeconds")) {
+        this.expirationOffsetSeconds = Integer.parseInt(configsMapForTheTopic.get("expirationOffsetSeconds"));
+        if (this.expirationOffsetSeconds < 0) {
+          throw new DataException("The setting expirationOffsetSeconds must not be negative.");
+        }
+      }
       if (configsMapForTheTopic.containsKey("consistencyLevel")) {
         this.consistencyLevel = DefaultConsistencyLevel.valueOf(configsMapForTheTopic.get("consistencyLevel"));
       }
     } catch (NumberFormatException e) {
       throw new DataException(
-              String.format("The setting ttlSeconds must be of type Integer. %s is not a supported type",
-                      configsMapForTheTopic.get("ttlSeconds").getClass().getName()));
+              "The settings ttlSeconds and expirationOffsetSeconds must be integers.", e);
     } catch (IllegalArgumentException e) {
       throw  new DataException(
               String.format("%s is not a valid value for consistencyLevel. Valid values are %s",
@@ -76,30 +84,36 @@ public class TopicConfigs {
 
   public void setTablePartitionAndColumnValues(SinkRecord record) {
     for (String mappedEntry : this.mappingStringForTopic.split(",")) {
-      String[] columnNameMap = mappedEntry.split("=");
-      String recordField = columnNameMap[1].split("\\.").length > 0
-              ? columnNameMap[1].split("\\.")[1] : "";
+      String[] columnNameMap = mappedEntry.trim().split("=", 2);
+      if (columnNameMap.length != 2) {
+        throw new DataException("Each mapping entry must have the form column=key.field, column=value.field or column=header.field.");
+      }
+      String recordFieldMapping = columnNameMap[1].trim();
+      String[] recordFieldParts = recordFieldMapping.split("\\.", 2);
+      String recordField = recordFieldParts.length == 2 ? recordFieldParts[1] : "";
       String scyllaColumnName = columnNameMap[0].trim();
       KafkaScyllaColumnMapper kafkaScyllaColumnMapper = new KafkaScyllaColumnMapper(scyllaColumnName);
-      if (columnNameMap[1].startsWith("key.")) {
+      if (recordFieldMapping.startsWith("key.")) {
         if (record.keySchema() != null) {
           kafkaScyllaColumnMapper.kafkaRecordField = getFiledForNameFromSchema(record.keySchema(), recordField, "record.keySchema()");
         }
         this.tablePartitionKeyMap.put(recordField, kafkaScyllaColumnMapper);
-      } else if (columnNameMap[1].startsWith("value.")) {
+      } else if (recordFieldMapping.startsWith("value.")) {
         Field valueField = null;
         if (record.valueSchema() != null) {
           valueField = getFiledForNameFromSchema(record.valueSchema(), recordField, "record.valueSchema()");
         }
         if (scyllaColumnName.equals("__ttl")) {
           ttlMappedField = recordField;
+        } else if (scyllaColumnName.equals("__expiration")) {
+          expirationMappedField = recordField;
         } else if (scyllaColumnName.equals("__timestamp")) {
           timeStampMappedField = recordField;
         } else {
           kafkaScyllaColumnMapper.kafkaRecordField = valueField;
           this.tableColumnMap.put(recordField, kafkaScyllaColumnMapper);
         }
-      } else if (columnNameMap[1].startsWith("header.")) {
+      } else if (recordFieldMapping.startsWith("header.")) {
         int index = 0;
         for (Header header : record.headers()) {
           if (header.key().equals(recordField)) {
@@ -116,6 +130,9 @@ public class TopicConfigs {
       } else {
         throw new IllegalArgumentException("field name must start with 'key.', 'value.' or 'header.'.");
       }
+    }
+    if (ttlMappedField != null && expirationMappedField != null) {
+      throw new DataException("A mapping cannot contain both __ttl and __expiration.");
     }
     this.isScyllaColumnsMapped = true;
   }
@@ -141,6 +158,10 @@ public class TopicConfigs {
   }
 
   public void setTtlAndTimeStampIfAvailable(SinkRecord record) {
+    setTtlAndTimeStampIfAvailable(record, System.currentTimeMillis());
+  }
+
+  void setTtlAndTimeStampIfAvailable(SinkRecord record, long currentTimeMillis) {
     // Timestamps in Kafka (record.timestamp()) are in millisecond precision,
     // while Scylla expects a microsecond precision: 1 ms = 1000 us.
     this.timeStamp = record.timestamp() * 1000;
@@ -165,6 +186,43 @@ public class TopicConfigs {
                         ttlMappedField, ttlValue.getClass().getName()
                 ));
       }
+    } else if (expirationMappedField != null) {
+      Object expirationValue = getValueOfField(record.value(), expirationMappedField);
+      final long expirationTimeMillis;
+      if (expirationValue instanceof Date) {
+        expirationTimeMillis = ((Date) expirationValue).getTime();
+      } else if (expirationValue instanceof Long) {
+        expirationTimeMillis = (Long) expirationValue;
+      } else {
+        throw new DataException(
+                String.format("Expiration should be a Kafka Timestamp or epoch-millisecond Long. "
+                                + "But record provided for %s is of type %s",
+                        expirationMappedField,
+                        expirationValue == null ? "null" : expirationValue.getClass().getName()));
+      }
+
+      final long expiresAtMillis;
+      try {
+        expiresAtMillis = Math.addExact(
+                expirationTimeMillis,
+                Math.multiplyExact((long) expirationOffsetSeconds, 1000L));
+      } catch (ArithmeticException e) {
+        throw new DataException("Expiration timestamp plus expirationOffsetSeconds is outside the supported range.", e);
+      }
+      final long remainingMillis;
+      try {
+        remainingMillis = Math.subtractExact(expiresAtMillis, currentTimeMillis);
+      } catch (ArithmeticException e) {
+        throw new DataException("Calculated expiration interval is outside the supported range.", e);
+      }
+      if (remainingMillis <= 0) {
+        throw new DataException("Expiration timestamp plus expirationOffsetSeconds must be in the future.");
+      }
+      long ttlSeconds = Math.floorDiv(remainingMillis - 1, 1000) + 1;
+      if (ttlSeconds > Integer.MAX_VALUE) {
+        throw new DataException("Calculated TTL exceeds the maximum supported integer value.");
+      }
+      this.ttl = (int) ttlSeconds;
     }
   }
 

--- a/src/test/java/io/connect/scylladb/ScyllaDbSinkConnectorConfigTest.java
+++ b/src/test/java/io/connect/scylladb/ScyllaDbSinkConnectorConfigTest.java
@@ -34,5 +34,19 @@ public class ScyllaDbSinkConnectorConfigTest {
     assertEquals(true, config.keyspaceCreateEnabled);
   }
 
+  @Test
+  public void shouldAcceptExpirationOffsetTopicConfig() {
+    settings.put(
+            "topic.events.scylladb.events.mapping",
+            "id=key.id, __expiration=value.validUntil");
+    settings.put(
+            "topic.events.scylladb.events.expirationOffsetSeconds",
+            "86400");
+
+    config = new ScyllaDbSinkConnectorConfig(settings);
+
+    assertNotNull(config.topicWiseConfigs.get("events"));
+  }
+
   //TODO: Add more tests
 }

--- a/src/test/java/io/connect/scylladb/topictotable/TopicConfigsTest.java
+++ b/src/test/java/io/connect/scylladb/topictotable/TopicConfigsTest.java
@@ -1,0 +1,138 @@
+package io.connect.scylladb.topictotable;
+
+import io.connect.scylladb.ScyllaDbSinkConnectorConfig;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class TopicConfigsTest {
+
+  private ScyllaDbSinkConnectorConfig connectorConfig;
+
+  @Before
+  public void before() {
+    Map<String, String> settings = new HashMap<>();
+    settings.put(ScyllaDbSinkConnectorConfig.KEYSPACE_CONFIG, "scylladb");
+    connectorConfig = new ScyllaDbSinkConnectorConfig(settings);
+  }
+
+  @Test
+  public void shouldCalculateTtlFromTimestampAndOffset() {
+    TopicConfigs configs = topicConfigs("__expiration=value.validUntil", "86400");
+    SinkRecord record = timestampRecord(new Date(1_010_000L));
+
+    configs.setTablePartitionAndColumnValues(record);
+    configs.setTtlAndTimeStampIfAvailable(record, 1_000_000L);
+
+    assertEquals(Integer.valueOf(86_410), configs.getTtl());
+  }
+
+  @Test
+  public void shouldCalculateTtlFromEpochMillisecondsAndRoundUp() {
+    TopicConfigs configs = topicConfigs("__expiration=value.validUntil", "0");
+    SinkRecord record = longRecord(1_001_001L);
+
+    configs.setTablePartitionAndColumnValues(record);
+    configs.setTtlAndTimeStampIfAvailable(record, 1_000_000L);
+
+    assertEquals(Integer.valueOf(2), configs.getTtl());
+  }
+
+  @Test
+  public void shouldCalculateTtlForSchemalessRecord() {
+    TopicConfigs configs = topicConfigs("__expiration=value.validUntil", "10");
+    Map<String, Object> key = new HashMap<>();
+    key.put("id", 1L);
+    Map<String, Object> value = new HashMap<>();
+    value.put("validUntil", 1_001_000L);
+    SinkRecord record = new SinkRecord("topic", 0, null, key, null, value, 0L, 1_000L, null);
+
+    configs.setTablePartitionAndColumnValues(record);
+    configs.setTtlAndTimeStampIfAvailable(record, 1_000_000L);
+
+    assertEquals(Integer.valueOf(11), configs.getTtl());
+  }
+
+  @Test
+  public void shouldKeepExistingRelativeTtlBehavior() {
+    TopicConfigs configs = topicConfigs("__ttl=value.ttl", "0");
+    Schema valueSchema = SchemaBuilder.struct()
+            .field("ttl", Schema.INT32_SCHEMA)
+            .build();
+    SinkRecord record = record(valueSchema, new Struct(valueSchema).put("ttl", 42));
+
+    configs.setTablePartitionAndColumnValues(record);
+    configs.setTtlAndTimeStampIfAvailable(record, 1_000_000L);
+
+    assertEquals(Integer.valueOf(42), configs.getTtl());
+  }
+
+  @Test(expected = DataException.class)
+  public void shouldRejectExpiredTimestamp() {
+    TopicConfigs configs = topicConfigs("__expiration=value.validUntil", "0");
+    SinkRecord record = longRecord(999_999L);
+
+    configs.setTablePartitionAndColumnValues(record);
+    configs.setTtlAndTimeStampIfAvailable(record, 1_000_000L);
+  }
+
+  @Test(expected = DataException.class)
+  public void shouldRejectTtlAndExpirationInSameMapping() {
+    TopicConfigs configs = topicConfigs(
+            "__ttl=value.ttl, __expiration=value.validUntil",
+            "0");
+    Schema valueSchema = SchemaBuilder.struct()
+            .field("ttl", Schema.INT32_SCHEMA)
+            .field("validUntil", Schema.INT64_SCHEMA)
+            .build();
+    Struct value = new Struct(valueSchema)
+            .put("ttl", 10)
+            .put("validUntil", 1_010_000L);
+
+    configs.setTablePartitionAndColumnValues(record(valueSchema, value));
+  }
+
+  @Test(expected = DataException.class)
+  public void shouldRejectNegativeExpirationOffset() {
+    topicConfigs("__expiration=value.validUntil", "-1");
+  }
+
+  private TopicConfigs topicConfigs(String mapping, String offsetSeconds) {
+    Map<String, String> settings = new HashMap<>();
+    settings.put("mapping", mapping);
+    settings.put("expirationOffsetSeconds", offsetSeconds);
+    return new TopicConfigs(settings, connectorConfig);
+  }
+
+  private SinkRecord timestampRecord(Date validUntil) {
+    Schema valueSchema = SchemaBuilder.struct()
+            .field("validUntil", org.apache.kafka.connect.data.Timestamp.SCHEMA)
+            .build();
+    return record(valueSchema, new Struct(valueSchema).put("validUntil", validUntil));
+  }
+
+  private SinkRecord longRecord(long validUntil) {
+    Schema valueSchema = SchemaBuilder.struct()
+            .field("validUntil", Schema.INT64_SCHEMA)
+            .build();
+    return record(valueSchema, new Struct(valueSchema).put("validUntil", validUntil));
+  }
+
+  private SinkRecord record(Schema valueSchema, Struct value) {
+    Schema keySchema = SchemaBuilder.struct()
+            .field("id", Schema.INT64_SCHEMA)
+            .build();
+    Struct key = new Struct(keySchema).put("id", 1L);
+    return new SinkRecord("topic", 0, keySchema, key, valueSchema, value, 0L, 1_000L, null);
+  }
+}


### PR DESCRIPTION
## Summary

Adds support for calculating ScyllaDB TTL dynamically from an absolute expiration timestamp, resolving #75.

Records can now expire at a timestamp stored in the Kafka value, optionally plus a configured offset—for example, one day after a validity date.

## Changes

- Add the `__expiration=value.<field>` topic mapping.
- Add `topic.<topic>.<keyspace>.<table>.expirationOffsetSeconds`.
- Support expiration values represented as:

  - Kafka Connect logical `Timestamp`
  - Unix epoch milliseconds in an `INT64` field

- Calculate per-record TTL as:

  ```
  ceil((expiration timestamp + offset - current time) / 1 second)
  ```

- Bind TTL values to a reusable prepared statement instead of preparing a new statement for each TTL.
- Preserve the existing `__ttl` relative-duration behavior.
- Reject invalid configurations and records, including:

  - mappings containing both `__ttl` and `__expiration`
  - negative offsets
  - expired timestamps
  - unsupported expiration field types
  - arithmetic overflow or TTL values outside the supported integer range

- Improve topic-mapping parsing to handle whitespace consistently.
- Document the feature in `README.md`, `CONFIG.md`, and `EXAMPLES.md`.

## Configuration example

```
topics=events
scylladb.keyspace=example_ks

topic.events.example_ks.events.mapping=id=key.id,payload=value.payload,__expiration=value.validUntil
topic.events.example_ks.events.expirationOffsetSeconds=86400
```

This expires each record one day after `validUntil`.

## Backward compatibility

The existing dynamic TTL mapping remains unchanged:

```
topic.events.example_ks.events.mapping=id=key.id,__ttl=value.ttl
```

Here, `value.ttl` continues to represent a relative lifetime in seconds.

## Testing

Added coverage for:

- Kafka Connect logical timestamps
- epoch-millisecond values
- TTL rounding
- expiration offsets
- schemaless records
- existing `__ttl` behavior
- conflicting mappings
- negative offsets
- already-expired timestamps
- topic-level configuration parsing

Validation performed:

```
mvn -q -DskipITs test
mvn -q -DskipITs package
git diff --check
```

All checks passed. Maven emits existing non-fatal Windows warnings for Unix-style assembly descriptor paths.

Closes #75.