### PR TITLE
Support schemaless nested UDT collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,36 @@ The ScyllaDB Sink Connector accepts two data formats from kafka. They are:
 
 **Note:** In case of JSON without schema, the table should already be present in the keyspace.
 
+Schemaless JSON collections must match the CQL column type. JSON arrays of objects can be
+stored as lists of frozen user-defined types. For example, this value:
+
+```json
+{
+  "systems_sids": [
+    {"sid": [], "system": "s1"},
+    {"sid": [], "system": "s2"}
+  ]
+}
+```
+
+requires a UDT and table column such as:
+
+```sql
+CREATE TYPE system_sid (
+    sid list<text>,
+    system text
+);
+
+CREATE TABLE ustime (
+    id text PRIMARY KEY,
+    systems_sids list<frozen<system_sid>>
+);
+```
+
+Declaring `systems_sids` as `list<text>` is only valid when every JSON array element is a
+string. The connector uses the prepared statement's CQL type to recursively convert nested
+schemaless lists, maps, and UDT values.
+
 This connector uses the topic name to determine the name of the table to write to. You can change this dynamically by using a
 transform like [Regex Router](<https://kafka.apache.org/documentation/#connect_transforms>) to change the topic name.
 

--- a/src/main/java/io/connect/scylladb/RecordToBoundStatementConverter.java
+++ b/src/main/java/io/connect/scylladb/RecordToBoundStatementConverter.java
@@ -1,18 +1,33 @@
 package io.connect.scylladb;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.data.SettableById;
+import com.datastax.oss.driver.api.core.data.UdtValue;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.ListType;
+import com.datastax.oss.driver.api.core.type.MapType;
+import com.datastax.oss.driver.api.core.type.UserDefinedType;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.net.InetAddress;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundStatementConverter.State> {
@@ -170,7 +185,7 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       Schema schema,
       List value
   ) {
-    state.statement = state.statement.setList(fieldName, value, Object.class);
+    state.statement = setCqlValue(state.statement, fieldName, value);
     state.parameters++;
   }
 
@@ -180,8 +195,196 @@ class RecordToBoundStatementConverter extends RecordConverter<RecordToBoundState
       Schema schema,
       Map value
   ) {
-    state.statement = state.statement.setMap(fieldName, value, Object.class, Object.class);
+    state.statement = setCqlValue(state.statement, fieldName, value);
     state.parameters++;
+  }
+
+  private BoundStatement setCqlValue(BoundStatement statement, String fieldName, Object value) {
+    ColumnDefinition definition = preparedStatement.getVariableDefinitions().get(fieldName);
+    if (definition == null) {
+      throw new DataException(String.format("No prepared statement variable found for field '%s'", fieldName));
+    }
+    return (BoundStatement)setCqlValue(statement, fieldName, value, definition.getType());
+  }
+
+  private SettableById setCqlValue(
+      SettableById target,
+      String fieldName,
+      Object value,
+      DataType dataType
+  ) {
+    CqlIdentifier identifier = CqlIdentifier.fromInternal(fieldName);
+    if (dataType instanceof UserDefinedType) {
+      if (!(value instanceof Map)) {
+        throw incompatibleType(fieldName, dataType, value);
+      }
+      return target.setUdtValue(identifier, toUdtValue(fieldName, (Map)value, (UserDefinedType)dataType));
+    }
+    if (dataType instanceof ListType) {
+      if (!(value instanceof List)) {
+        throw incompatibleType(fieldName, dataType, value);
+      }
+      DataType elementType = ((ListType)dataType).getElementType();
+      List<Object> converted = new ArrayList<>(((List)value).size());
+      for (Object element : (List)value) {
+        converted.add(toCqlValue(fieldName, element, elementType));
+      }
+      return target.setList(identifier, converted, javaType(elementType));
+    }
+    if (dataType instanceof MapType) {
+      if (!(value instanceof Map)) {
+        throw incompatibleType(fieldName, dataType, value);
+      }
+      MapType mapType = (MapType)dataType;
+      Map<Object, Object> converted = new LinkedHashMap<>();
+      for (Object entryObject : ((Map)value).entrySet()) {
+        Map.Entry entry = (Map.Entry)entryObject;
+        converted.put(
+            toCqlValue(fieldName, entry.getKey(), mapType.getKeyType()),
+            toCqlValue(fieldName, entry.getValue(), mapType.getValueType())
+        );
+      }
+      return target.setMap(
+          identifier,
+          converted,
+          javaType(mapType.getKeyType()),
+          javaType(mapType.getValueType())
+      );
+    }
+    return target.set(identifier, value, value.getClass());
+  }
+
+  private Object toCqlValue(String fieldName, Object value, DataType dataType) {
+    if (value == null) {
+      return null;
+    }
+    if (dataType instanceof UserDefinedType) {
+      if (!(value instanceof Map)) {
+        throw incompatibleType(fieldName, dataType, value);
+      }
+      return toUdtValue(fieldName, (Map)value, (UserDefinedType)dataType);
+    }
+    if (dataType instanceof ListType) {
+      if (!(value instanceof List)) {
+        throw incompatibleType(fieldName, dataType, value);
+      }
+      DataType elementType = ((ListType)dataType).getElementType();
+      List<Object> converted = new ArrayList<>(((List)value).size());
+      for (Object element : (List)value) {
+        converted.add(toCqlValue(fieldName, element, elementType));
+      }
+      return converted;
+    }
+    if (dataType instanceof MapType) {
+      if (!(value instanceof Map)) {
+        throw incompatibleType(fieldName, dataType, value);
+      }
+      MapType mapType = (MapType)dataType;
+      Map<Object, Object> converted = new LinkedHashMap<>();
+      for (Object entryObject : ((Map)value).entrySet()) {
+        Map.Entry entry = (Map.Entry)entryObject;
+        converted.put(
+            toCqlValue(fieldName, entry.getKey(), mapType.getKeyType()),
+            toCqlValue(fieldName, entry.getValue(), mapType.getValueType())
+        );
+      }
+      return converted;
+    }
+    return value;
+  }
+
+  private UdtValue toUdtValue(String fieldName, Map value, UserDefinedType userDefinedType) {
+    UdtValue udtValue = userDefinedType.newValue();
+    for (Object key : value.keySet()) {
+      if (!(key instanceof String) || !userDefinedType.contains((String)key)) {
+        throw new DataException(
+            String.format("Field '%s' contains unknown UDT field '%s' for type %s", fieldName, key, userDefinedType)
+        );
+      }
+      Object fieldValue = value.get(key);
+      if (fieldValue == null) {
+        udtValue = udtValue.setToNull((String)key);
+      } else {
+        DataType fieldType = userDefinedType.getFieldTypes().get(userDefinedType.firstIndexOf((String)key));
+        udtValue = (UdtValue)setCqlValue(udtValue, (String)key, fieldValue, fieldType);
+      }
+    }
+    return udtValue;
+  }
+
+  private Class javaType(DataType dataType) {
+    if (dataType instanceof UserDefinedType) {
+      return UdtValue.class;
+    }
+    if (dataType instanceof ListType) {
+      return List.class;
+    }
+    if (dataType instanceof MapType) {
+      return Map.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.ASCII)
+        || dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.TEXT)) {
+      return String.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.BOOLEAN)) {
+      return Boolean.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.TINYINT)) {
+      return Byte.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.SMALLINT)) {
+      return Short.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.INT)) {
+      return Integer.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.BIGINT)
+        || dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.COUNTER)) {
+      return Long.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.FLOAT)) {
+      return Float.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.DOUBLE)) {
+      return Double.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.DECIMAL)) {
+      return BigDecimal.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.VARINT)) {
+      return BigInteger.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.BLOB)) {
+      return ByteBuffer.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.TIMESTAMP)) {
+      return Instant.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.DATE)) {
+      return LocalDate.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.TIME)) {
+      return LocalTime.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.UUID)
+        || dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.TIMEUUID)) {
+      return UUID.class;
+    }
+    if (dataType.equals(com.datastax.oss.driver.api.core.type.DataTypes.INET)) {
+      return InetAddress.class;
+    }
+    return Object.class;
+  }
+
+  private DataException incompatibleType(String fieldName, DataType dataType, Object value) {
+    return new DataException(
+        String.format(
+            "Field '%s' expects CQL type %s but received %s",
+            fieldName,
+            dataType,
+            value == null ? "null" : value.getClass().getName()
+        )
+    );
   }
 
   protected void setNullField(

--- a/src/test/java/io/connect/scylladb/RecordToBoundStatementConverterTest.java
+++ b/src/test/java/io/connect/scylladb/RecordToBoundStatementConverterTest.java
@@ -1,0 +1,99 @@
+package io.connect.scylladb;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinition;
+import com.datastax.oss.driver.api.core.cql.ColumnDefinitions;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.data.UdtValue;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.core.type.ListType;
+import com.datastax.oss.driver.api.core.type.UserDefinedType;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RecordToBoundStatementConverterTest {
+
+  @Test
+  public void convertsSchemalessListOfMapsToListOfUdtValues() {
+    PreparedStatement preparedStatement = mock(PreparedStatement.class);
+    BoundStatement boundStatement = mock(BoundStatement.class);
+    ColumnDefinitions definitions = mock(ColumnDefinitions.class);
+    ColumnDefinition definition = mock(ColumnDefinition.class);
+    ListType listType = mock(ListType.class);
+    UserDefinedType udtType = mock(UserDefinedType.class);
+    UdtValue firstUdtValue = mock(UdtValue.class);
+    UdtValue secondUdtValue = mock(UdtValue.class);
+
+    when(preparedStatement.getVariableDefinitions()).thenReturn(definitions);
+    when(definitions.get("systems_sids")).thenReturn(definition);
+    when(definition.getType()).thenReturn(listType);
+    when(listType.getElementType()).thenReturn(udtType);
+    when(udtType.newValue()).thenReturn(firstUdtValue, secondUdtValue);
+    when(udtType.contains("sid")).thenReturn(true);
+    when(udtType.contains("system")).thenReturn(true);
+    when(udtType.firstIndexOf("sid")).thenReturn(0);
+    when(udtType.firstIndexOf("system")).thenReturn(1);
+    when(udtType.getFieldTypes()).thenReturn(
+        Arrays.asList(DataTypes.listOf(DataTypes.TEXT), DataTypes.TEXT)
+    );
+    when(firstUdtValue.setList(
+        CqlIdentifier.fromInternal("sid"), Collections.emptyList(), String.class
+    )).thenReturn(firstUdtValue);
+    when(firstUdtValue.set(
+        CqlIdentifier.fromInternal("system"), "s1", String.class
+    )).thenReturn(firstUdtValue);
+    when(secondUdtValue.setList(
+        CqlIdentifier.fromInternal("sid"), Collections.emptyList(), String.class
+    )).thenReturn(secondUdtValue);
+    when(secondUdtValue.set(
+        CqlIdentifier.fromInternal("system"), "s2", String.class
+    )).thenReturn(secondUdtValue);
+    when(boundStatement.setList(
+        CqlIdentifier.fromInternal("systems_sids"),
+        Arrays.asList(firstUdtValue, secondUdtValue),
+        UdtValue.class
+    )).thenReturn(boundStatement);
+
+    Map<String, Object> first = new LinkedHashMap<>();
+    first.put("sid", Collections.emptyList());
+    first.put("system", "s1");
+    Map<String, Object> second = new LinkedHashMap<>();
+    second.put("sid", Collections.emptyList());
+    second.put("system", "s2");
+    List<Map<String, Object>> value = Arrays.asList(first, second);
+
+    RecordToBoundStatementConverter converter = new RecordToBoundStatementConverter(preparedStatement);
+    RecordToBoundStatementConverter.State state =
+        new RecordToBoundStatementConverter.State(boundStatement);
+
+    converter.setArray(state, "systems_sids", null, value);
+
+    verify(firstUdtValue).setList(
+        CqlIdentifier.fromInternal("sid"), Collections.emptyList(), String.class
+    );
+    verify(firstUdtValue).set(
+        CqlIdentifier.fromInternal("system"), "s1", String.class
+    );
+    verify(secondUdtValue).setList(
+        CqlIdentifier.fromInternal("sid"), Collections.emptyList(), String.class
+    );
+    verify(secondUdtValue).set(
+        CqlIdentifier.fromInternal("system"), "s2", String.class
+    );
+    verify(boundStatement).setList(
+        CqlIdentifier.fromInternal("systems_sids"),
+        Arrays.asList(firstUdtValue, secondUdtValue),
+        UdtValue.class
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #101 by adding support for nested objects inside schemaless JSON collections.

## Root cause

Schemaless JSON arrays were bound as `List<Object>`. When an array contained JSON objects, the ScyllaDB driver could not encode those maps as UDT values, resulting in errors such as:

```
Codec not found for requested operation: [TEXT <-> java.util.List<java.lang.Object>]
```

Declaring the destination column as `list<text>` also conflicts with the payload because its elements are objects rather than strings.

## Changes

- Use the prepared statement’s CQL metadata when binding schemaless collections.
- Recursively convert nested lists, maps, and JSON objects.
- Convert JSON objects to `UdtValue` when the corresponding CQL type is a UDT.
- Return clearer errors for incompatible CQL and JSON types or unknown UDT fields.
- Document the correct schema for the example from #101:

```
CREATE TYPE system_sid (
    sid list<text>,
    system text
);

CREATE TABLE ustime (
    id text PRIMARY KEY,
    systems_sids list<frozen<system_sid>>
);
```

- Add a regression test covering a schemaless `list<UDT>` with nested empty lists.

## Impact

Schemaless records can now persist arrays of nested objects when the destination column uses a matching UDT collection type. Existing primitive list and map handling remains supported.

## Testing

```
mvn clean test
Tests run: 26, Failures: 0, Errors: 0, Skipped: 0
```