### PR TITLE
fix(cve): remediate CVE-2026-59901 (netty) and CVE-2026-59949 (lz4-java)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <scylladb.version>4.19.2.0</scylladb.version>
         <skipIntegrationTests>false</skipIntegrationTests>
         <!-- transitive dependency versions -->
+        <netty.version>4.1.136.Final</netty.version>
         <jackson.version>2.21.5</jackson.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <guava.version>33.6.0-jre</guava.version>
@@ -247,6 +248,15 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- CVE-2026-59901: force netty to 4.1.136.Final; remove once a scylladb/java-driver
+                 release containing scylladb/java-driver#978 is consumed here (Stage 3). -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
@@ -362,7 +372,7 @@
             <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
             <!-- should match version from drivers POM -->
-            <version>1.11.0</version>
+            <version>1.11.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary

Closes #203 (Stage 1)

A Confluent Hub security scan flagged connector `1.1.7` for two CVEs. This PR remediates both; since v1.1.7 has already been released, the fix ships in **1.1.8**.

| CVE | Severity | CVSS | Package | 1.1.7 | This PR |
|---|---|---|---|---|---|
| [CVE-2026-59901](https://avd.aquasec.com/nvd/cve-2026-59901) | HIGH | NA | `io.netty:netty-codec` | 4.1.135.Final | **4.1.136.Final** |
| [CVE-2026-59949](https://avd.aquasec.com/nvd/cve-2026-59949) | MEDIUM | 6.5 | `at.yawk.lz4:lz4-java` | 1.11.0 | **1.11.1** |

`netty` is transitive via `java-driver-core:4.19.2.0`, so it is forced with a `<dependencyManagement>` BOM import — the same **Stage 1** workaround used in #165 and #185. `lz4-java` is a direct dependency and is bumped in place.

The upstream root fix (Stage 2) is **already merged** as scylladb/java-driver#978, but no driver release containing it has been cut — the latest on Maven Central is `4.19.2.0` (2026-06-25), which still ships netty `4.1.135.Final`. The override bridges that gap.

## Changes

`pom.xml` only:

- add `<netty.version>4.1.136.Final</netty.version>` property
- add `io.netty:netty-bom` import to `<dependencyManagement>`, commented with the CVE and its Stage 3 removal condition
- bump `at.yawk.lz4:lz4-java` from `1.11.0` to `1.11.1` (matches the driver's `scylla-4.x` branch, keeping the existing "should match version from drivers POM" invariant true)

## Verification

Rebased onto current `master` (`83e87c68`), so the scan sees this branch's changes on top of the jackson `2.21.5` fixes already merged via #194 / #198 — this PR touches neither the jackson versions nor the project version.

All 7 netty artifacts pick up the BOM, and lz4-java resolves to the fixed version:

```
$ mvn dependency:tree
[INFO] |  +- io.netty:netty-handler:jar:4.1.136.Final:compile
[INFO] |  |  +- io.netty:netty-common:jar:4.1.136.Final:compile
[INFO] |  |  +- io.netty:netty-resolver:jar:4.1.136.Final:compile
[INFO] |  |  +- io.netty:netty-buffer:jar:4.1.136.Final:compile
[INFO] |  |  +- io.netty:netty-transport:jar:4.1.136.Final:compile
[INFO] |  |  +- io.netty:netty-transport-native-unix-common:jar:4.1.136.Final:compile
[INFO] |  |  \- io.netty:netty-codec:jar:4.1.136.Final:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.21.5:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.21.5:compile
[INFO] +- at.yawk.lz4:lz4-java:jar:1.11.1:compile
[INFO] BUILD SUCCESS
```

Negative check — no stale copy survives anywhere in the tree:

```
$ mvn dependency:tree | grep -E "4\.1\.135\.Final|lz4-java:jar:1\.11\.0|jackson[a-z-]*:jar:2\.21\.3"
(no matches)
```

Full build green locally, including the Dockerised integration suite against `scylladb/scylla:latest`:

```
$ mvn -B verify
[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0   # unit (surefire)
[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 3   # integration (failsafe)
[INFO] BUILD SUCCESS
[INFO] Total time:  11:38 min
```

## Exposure

Neither CVE is believed reachable through this connector's code paths: the driver uses netty for the CQL binary protocol, so `Bzip2Decoder` is never installed in the pipeline, and `lz4-java` is called by the driver's frame compressor with correctly bounded arrays (the lz4 advisory explicitly excludes the attacker-controlled-*contents* case). That assessment is best-effort and not instrumented — and the bumps are required for a clean Confluent Hub scan regardless.

## Follow-up

**Stage 3:** once a `scylladb/java-driver` release containing #978 is published, bump `scylladb.version` here and **delete the netty-bom override** — the same cleanup #167 performed for the previous override.

## Supersedes

- #201 (dependabot) — `lz4-java` 1.11.0 → 1.11.1
- #202 (renovate) — `lz4-java` 1.11.0 → 1.11.1

Both are safe to close once this merges.
