### PR TITLE
fix(cve): bump scylladb driver to 4.19.2.1 and drop netty-bom override (Stage 3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,10 +18,9 @@
         <failsafe.version>3.5.6</failsafe.version>
         <kafka.version>3.9.2</kafka.version>
         <junit.version>5.14.4</junit.version>
-        <scylladb.version>4.19.2.0</scylladb.version>
+        <scylladb.version>4.19.2.1</scylladb.version>
         <skipIntegrationTests>false</skipIntegrationTests>
         <!-- transitive dependency versions -->
-        <netty.version>4.1.136.Final</netty.version>
         <jackson.version>2.21.5</jackson.version>
         <jackson-annotations.version>2.21</jackson-annotations.version>
         <guava.version>33.6.0-jre</guava.version>
@@ -248,15 +247,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- CVE-2026-59901: force netty to 4.1.136.Final; remove once a scylladb/java-driver
-                 release containing scylladb/java-driver#978 is consumed here (Stage 3). -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>${netty.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>


### PR DESCRIPTION
> [!WARNING]
> **BLOCKED — do not merge yet. CI is red on purpose.**
> `com.scylladb:java-driver-core:4.19.2.1` **has not been published**. This PR is staged in advance so it is ready the moment that release lands. The red build is *only* dependency resolution failing on the unpublished artifact — nothing about the change itself is broken.

## Summary

Stage 3 of the CVE-2026-59901 remediation tracked in #203 and delivered as Stage 1 in #204.

#204 pinned netty to `4.1.136.Final` with a temporary `netty-bom` override because the CVE arrived transitively through the driver and no fixed driver release existed. The upstream root fix has since merged — scylladb/java-driver#978 put `netty.version` `4.1.136.Final` (and `lz4.version` `1.11.1`) on the driver's `scylla-4.x` branch — so once a release ships it, the connector can inherit the fixed netty directly and the override becomes dead weight.

This is the same cleanup that `9084845` performed for the previous override cycle (#165 / #185).

## Changes

`pom.xml` only:

- `scylladb.version` `4.19.2.0` → `4.19.2.1`
- remove the `<netty.version>` property
- remove the `io.netty:netty-bom` `<dependencyManagement>` import and its CVE comment

`lz4-java` deliberately stays at `1.11.1` — it is a direct dependency pinned to match the driver POM, and the driver's `scylla-4.x` is on `1.11.1`, so the existing `<!-- should match version from drivers POM -->` invariant already holds.

Net: `pom.xml` returns to its pre-#204 shape, except the driver is `4.19.2.1` and `lz4-java` remains `1.11.1`.

## Why it is blocked

`scylla-4.x` sits at `4.19.2.1-SNAPSHOT`, 13 commits ahead of the `4.19.2.0` tag. There is no `4.19.2.1` release, git tag, or published snapshot — Maven Central's `lastUpdated` for `java-driver-core` is still `20260625`, and `4.19.2.1/{pom,jar}` both 404.

```
$ mvn -B compile
[ERROR] Failed to execute goal on project kafka-connect-scylladb: Could not resolve dependencies
[ERROR] dependency: com.scylladb:java-driver-core:jar:4.19.2.1 (compile)
[ERROR] 	Could not find artifact com.scylladb:java-driver-core:jar:4.19.2.1 in confluent (https://packages.confluent.io/maven/)
[ERROR] 	Could not find artifact com.scylladb:java-driver-core:jar:4.19.2.1 in central (https://repo.maven.apache.org/maven2)
[INFO] BUILD FAILURE
```

Note that `mvn dependency:tree` misleadingly reports `BUILD SUCCESS` here — it only warns (`The POM for com.scylladb:java-driver-core:jar:4.19.2.1 is missing`) and then renders the driver as a childless leaf with no netty beneath it. Use a goal that actually resolves JARs when checking this.

Pinning a `-SNAPSHOT` or adding a snapshot repository was deliberately not done — a released connector must not depend on a snapshot.

## What was verified now

- `pom.xml` is well-formed XML after the block removal.
- The diff against `master` is exactly the three changes above and nothing else — `jackson.version` still `2.21.5`, project version still `1.1.8-SNAPSHOT`, `lz4-java` still `1.11.1`.
- The premise still holds: `scylla-4.x` declares `netty.version` `4.1.136.Final` and `lz4.version` `1.11.1`, so dropping the override is safe once that ships.

## Before merging — once 4.19.2.1 is published

- [ ] Rebase on `master`
- [ ] `mvn dependency:tree` — all 7 netty artifacts resolve to `4.1.136.Final` **from the driver alone**, override gone; `lz4-java` `1.11.1`; jackson `2.21.5`
- [ ] Negative check — `mvn dependency:tree | grep -E "4\.1\.135\.Final|lz4-java:jar:1\.11\.0"` returns nothing
- [ ] `mvn -B verify` green (25 unit + 38 integration tests)
- [ ] `security/snyk` and `Run all tests` green, then mark ready for review

If the driver releases under a different version instead (e.g. `4.19.3.0`), retarget to that and confirm **it** contains #978 before assuming the override is safe to drop.
