### PR TITLE
chore: drop dead distributionManagement release repo (DRIVER-438)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -514,10 +514,6 @@
             <id>central</id>
             <url>https://central.sonatype.com/repository/maven-snapshots</url>
         </snapshotRepository>
-        <repository>
-            <id>central</id>
-            <url>https://central.sonatype.com/repository/maven-releases</url>
-        </repository>
     </distributionManagement>
 
     <developers>


### PR DESCRIPTION
Removes the `<distributionManagement><repository>` entry. Its URL (`central.sonatype.com/repository/maven-releases`) is the Central Portal's read proxy for *consuming* releases, not a publish endpoint — nothing ever uploaded there.

It is inert because `central-publishing-maven-plugin` sets `extensions=true` and owns the `deploy` phase; `maven-deploy-plugin` never runs. Its only real effect was to mislead anyone running a bare `mvn deploy` outside `-Prelease`.

Verified: ran `mvn -Prelease deploy` on a non-SNAPSHOT version with and without the block — both reach the same `injected-central-publishing` goal and behave identically. Release path unaffected.

`<snapshotRepository>` is kept — Portal snapshots *are* published by ordinary `deploy` to that URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)